### PR TITLE
Wire boot-error and generation-error to React error boundary

### DIFF
--- a/src/components/game-container.test.tsx
+++ b/src/components/game-container.test.tsx
@@ -7,6 +7,7 @@ const mockDestroyGame = vi.fn();
 const mockGetActiveBus = vi.fn().mockReturnValue(null);
 const mockGetActiveSeed = vi.fn().mockReturnValue(null);
 const mockGetActiveMinimapInit = vi.fn().mockReturnValue(null);
+const mockGetActiveError = vi.fn().mockReturnValue(null);
 
 vi.mock("@/game/PhaserGame", () => ({
   createGame: mockCreateGame,
@@ -14,6 +15,7 @@ vi.mock("@/game/PhaserGame", () => ({
   getActiveBus: mockGetActiveBus,
   getActiveSeed: mockGetActiveSeed,
   getActiveMinimapInit: mockGetActiveMinimapInit,
+  getActiveError: mockGetActiveError,
 }));
 
 const { mockDisconnect, mockConnectBridge } = vi.hoisted(() => {
@@ -218,4 +220,80 @@ test("disconnects bridge on unmount after successful connection", async () => {
 
   unmount();
   expect(mockDisconnect).toHaveBeenCalledTimes(1);
+});
+
+test("throws to error boundary when getActiveError returns an error during polling", async () => {
+  vi.useFakeTimers();
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  // Simulate a boot-error captured by PhaserGame listeners
+  const bootError = new Error("Failed to generate tileset");
+  mockGetActiveError.mockReturnValue(bootError);
+
+  render(
+    <TestErrorBoundary>
+      <GameContainer />
+    </TestErrorBoundary>,
+  );
+
+  // Flush dynamic import + first rAF poll
+  await vi.advanceTimersByTimeAsync(20);
+
+  await vi.waitFor(() => {
+    expect(screen.getByTestId("boundary-error")).toBeInTheDocument();
+  });
+  expect(screen.getByTestId("boundary-error").textContent).toBe(
+    "Failed to generate tileset",
+  );
+
+  consoleSpy.mockRestore();
+});
+
+test("checks for errors before checking for bus", async () => {
+  vi.useFakeTimers();
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const fakeBus = { on: vi.fn(), off: vi.fn(), listeners: vi.fn().mockReturnValue([]) };
+
+  // Both error and bus available — error should take priority
+  mockGetActiveError.mockReturnValue(new Error("boot failed"));
+  mockGetActiveBus.mockReturnValue(fakeBus);
+
+  render(
+    <TestErrorBoundary>
+      <GameContainer />
+    </TestErrorBoundary>,
+  );
+
+  await vi.advanceTimersByTimeAsync(20);
+
+  await vi.waitFor(() => {
+    expect(screen.getByTestId("boundary-error")).toBeInTheDocument();
+  });
+  // Bridge should NOT have been connected
+  expect(mockConnectBridge).not.toHaveBeenCalled();
+
+  consoleSpy.mockRestore();
+});
+
+test("does not set error state if unmounted when boot error is detected", async () => {
+  vi.useFakeTimers();
+
+  const { unmount } = render(
+    <TestErrorBoundary>
+      <GameContainer />
+    </TestErrorBoundary>,
+  );
+
+  // Unmount before the polling can detect the error
+  unmount();
+
+  // Now simulate error appearing
+  mockGetActiveError.mockReturnValue(new Error("late boot error"));
+
+  // Advance timers — cancelled guard should prevent setError
+  for (let i = 0; i < 50; i++) {
+    await vi.advanceTimersByTimeAsync(20);
+  }
+
+  expect(screen.queryByTestId("boundary-error")).not.toBeInTheDocument();
 });

--- a/src/components/game-container.tsx
+++ b/src/components/game-container.tsx
@@ -16,7 +16,7 @@ export default function GameContainer() {
     let bridge: BridgeConnection | null = null;
 
     import("@/game/PhaserGame")
-      .then(({ createGame, destroyGame, getActiveBus, getActiveSeed, getActiveMinimapInit }) => {
+      .then(({ createGame, destroyGame, getActiveBus, getActiveSeed, getActiveMinimapInit, getActiveError }) => {
         if (cancelled) return;
         createGame("game-container");
         destroy = destroyGame;
@@ -30,6 +30,16 @@ export default function GameContainer() {
 
         const tryConnect = () => {
           if (cancelled) return;
+
+          // Check for boot/loading errors before checking the bus.
+          // These fire on Phaser's native emitter before the typed bus exists.
+          const gameError = getActiveError();
+          if (gameError) {
+            console.error("[GameContainer] Game boot/loading error:", gameError);
+            setError(gameError);
+            return;
+          }
+
           const bus = getActiveBus();
           if (bus) {
             bridge = connectBridge(bus);

--- a/src/game/PhaserGame.test.ts
+++ b/src/game/PhaserGame.test.ts
@@ -9,6 +9,8 @@ import {
   getActiveBus,
   setActiveSeed,
   getActiveSeed,
+  setActiveError,
+  getActiveError,
 } from "@/game/PhaserGame";
 import { createGameEventBus } from "@/game/events/event-bus";
 import BootScene from "@/game/scenes/boot-scene";
@@ -217,5 +219,96 @@ describe("seed accessors", () => {
     expect(getActiveSeed()).toBeNull();
 
     container.remove();
+  });
+});
+
+describe("error accessors", () => {
+  afterEach(() => {
+    setActiveError(null);
+  });
+
+  it("getActiveError returns null before any error is set", () => {
+    expect(getActiveError()).toBeNull();
+  });
+
+  it("setActiveError makes getActiveError return the error", () => {
+    const err = new Error("test error");
+    setActiveError(err);
+    expect(getActiveError()).toBe(err);
+  });
+
+  it("setActiveError(null) clears the error", () => {
+    setActiveError(new Error("will be cleared"));
+    setActiveError(null);
+    expect(getActiveError()).toBeNull();
+  });
+
+  it("destroyGame clears activeError", () => {
+    const container = document.createElement("div");
+    container.id = "error-test";
+    document.body.appendChild(container);
+
+    createGame("error-test");
+    setActiveError(new Error("boot failure"));
+    expect(getActiveError()).not.toBeNull();
+
+    destroyGame();
+    expect(getActiveError()).toBeNull();
+
+    container.remove();
+  });
+});
+
+describe("boot/loading error listeners", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.id = "err-listener-test";
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    destroyGame();
+    container.remove();
+  });
+
+  it("captures boot-error emitted on game.events", () => {
+    const game = createGame("err-listener-test");
+    expect(getActiveError()).toBeNull();
+
+    const err = new Error("tileset generation failed");
+    game.events.emit("boot-error", err);
+
+    expect(getActiveError()).toBe(err);
+  });
+
+  it("captures generation-error emitted on game.events", () => {
+    const game = createGame("err-listener-test");
+    expect(getActiveError()).toBeNull();
+
+    const err = new Error("world generation failed");
+    game.events.emit("generation-error", err);
+
+    expect(getActiveError()).toBe(err);
+  });
+
+  it("wraps non-Error values in an Error", () => {
+    const game = createGame("err-listener-test");
+
+    game.events.emit("boot-error", "string error");
+
+    const captured = getActiveError();
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured!.message).toBe("string error");
+  });
+
+  it("last error wins when multiple errors fire", () => {
+    const game = createGame("err-listener-test");
+
+    game.events.emit("boot-error", new Error("first"));
+    game.events.emit("generation-error", new Error("second"));
+
+    expect(getActiveError()!.message).toBe("second");
   });
 });

--- a/src/game/PhaserGame.ts
+++ b/src/game/PhaserGame.ts
@@ -35,6 +35,13 @@ let activeSeed: string | null = null;
  */
 let activeMinimapInit: MinimapInitEvent | null = null;
 
+/**
+ * Module-scoped error captured from BootScene or LoadingScene.
+ * These errors fire on Phaser's native `game.events` emitter — before
+ * the typed GameEventBus exists — so they cannot flow through the
+ * bridge.  Stored here for the React layer to poll via getActiveError().
+ */
+let activeError: Error | null = null;
 
 /**
  * Build the Phaser game configuration without creating an instance.
@@ -97,6 +104,17 @@ export function createGame(parentId: string): Phaser.Game {
   }
 
   instance = new Phaser.Game(buildGameConfig(parentId));
+
+  // Listen for pre-bus errors emitted on Phaser's native event system.
+  // These fire during BootScene/LoadingScene — before the typed GameEventBus
+  // exists — so we capture them in module scope for React to poll.
+  instance.events.on("boot-error", (err: unknown) => {
+    activeError = err instanceof Error ? err : new Error(String(err));
+  });
+  instance.events.on("generation-error", (err: unknown) => {
+    activeError = err instanceof Error ? err : new Error(String(err));
+  });
+
   return instance;
 }
 
@@ -112,6 +130,7 @@ export function destroyGame(): void {
   activeBus = null;
   activeSeed = null;
   activeMinimapInit = null;
+  activeError = null;
   try {
     ref.destroy(true);
   } catch (err) {
@@ -156,5 +175,19 @@ export function setActiveMinimapInit(data: MinimapInitEvent | null): void {
 /** Read-only accessor for minimap init data (or null). */
 export function getActiveMinimapInit(): MinimapInitEvent | null {
   return activeMinimapInit;
+}
+
+// ---------------------------------------------------------------------------
+// Error accessors — pre-bus errors from BootScene / LoadingScene
+// ---------------------------------------------------------------------------
+
+/** Called internally when boot-error or generation-error fires. Exported for tests. */
+export function setActiveError(error: Error | null): void {
+  activeError = error;
+}
+
+/** Read-only accessor for the first boot/loading error (or null). */
+export function getActiveError(): Error | null {
+  return activeError;
 }
 

--- a/src/game/__mocks__/phaser.ts
+++ b/src/game/__mocks__/phaser.ts
@@ -31,8 +31,31 @@ const Phaser = {
   },
   Game: class MockGame {
     config: unknown;
+    events: {
+      on: (event: string, fn: (...args: unknown[]) => void) => void;
+      off: (event: string, fn: (...args: unknown[]) => void) => void;
+      emit: (event: string, ...args: unknown[]) => void;
+    };
     constructor(config: unknown) {
       this.config = config;
+      const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+      this.events = {
+        on(event: string, fn: (...args: unknown[]) => void) {
+          (listeners[event] ??= []).push(fn);
+        },
+        off(event: string, fn: (...args: unknown[]) => void) {
+          const arr = listeners[event];
+          if (arr) {
+            const idx = arr.indexOf(fn);
+            if (idx !== -1) arr.splice(idx, 1);
+          }
+        },
+        emit(event: string, ...args: unknown[]) {
+          for (const fn of listeners[event] ?? []) {
+            fn(...args);
+          }
+        },
+      };
     }
     destroy() {}
   },


### PR DESCRIPTION
## Summary
- Adds listeners for `boot-error` and `generation-error` on `game.events` in `createGame()`, capturing errors into a module-scoped `activeError` singleton
- GameContainer polling loop checks `getActiveError()` before checking the bus, short-circuiting to throw to the existing `/play/error.tsx` boundary
- Follows the same pull-based pattern used for `activeSeed` and `activeMinimapInit`
- 11 new tests covering error capture, priority, wrapping, and unmount safety

Resolves #63

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified. Tests pass. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)