### PR TITLE
Cap notification array growth in useUIStore

### DIFF
--- a/src/stores/useUIStore.test.ts
+++ b/src/stores/useUIStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useUIStore } from "./useUIStore";
+import { useUIStore, MAX_NOTIFICATIONS } from "./useUIStore";
 
 describe("useUIStore", () => {
   beforeEach(() => {
@@ -67,6 +67,25 @@ describe("useUIStore", () => {
       const notifications = useUIStore.getState().notifications;
       expect(notifications).toHaveLength(1);
       expect(notifications[0].message).toBe("Test notification");
+    });
+
+    it("caps notifications at MAX_NOTIFICATIONS, keeping newest", () => {
+      for (let i = 0; i < MAX_NOTIFICATIONS + 10; i++) {
+        useUIStore.getState().addNotification({
+          id: `n${i}`,
+          message: `Notification ${i}`,
+          type: "info",
+          timestamp: i * 1000,
+        });
+      }
+
+      const notifications = useUIStore.getState().notifications;
+      expect(notifications).toHaveLength(MAX_NOTIFICATIONS);
+      // Oldest entries (0-9) should have been evicted
+      expect(notifications[0].id).toBe("n10");
+      expect(notifications[notifications.length - 1].id).toBe(
+        `n${MAX_NOTIFICATIONS + 9}`,
+      );
     });
 
     it("dismisses a notification by ID", () => {

--- a/src/stores/useUIStore.ts
+++ b/src/stores/useUIStore.ts
@@ -10,6 +10,13 @@ import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of notifications kept in the queue. Oldest are evicted first. */
+export const MAX_NOTIFICATIONS = 20;
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -125,7 +132,7 @@ export const useUIStore = create<UIStoreState & UIStoreActions>()(
 
     addNotification: (notification) =>
       set((state) => ({
-        notifications: [...state.notifications, notification],
+        notifications: [...state.notifications, notification].slice(-MAX_NOTIFICATIONS),
       })),
 
     dismissNotification: (id) =>


### PR DESCRIPTION
## Summary
- Caps `notifications` array in `useUIStore` at 20 entries using `.slice(-MAX_NOTIFICATIONS)`, evicting oldest first
- Follows the existing `addNoiseIndicator` pattern (`.slice(-10)`) already in the same store
- Prevents unbounded array growth during 15-20 minute gameplay sessions with active barricading and item pickups

Resolves #69

## Review
Reviewed by the Forge Temperer. Acceptance criteria met. Pattern consistency verified against existing `addNoiseIndicator`. All tests pass (2066/2066).

🤖 Generated with [Claude Code](https://claude.com/claude-code)