### PR TITLE
Reset session Zustand stores on game session end

### DIFF
--- a/src/components/death-screen.tsx
+++ b/src/components/death-screen.tsx
@@ -7,8 +7,8 @@ import { Button } from "@/components/ui/button";
 import { useUIStore } from "@/stores/useUIStore";
 import { useGameStore } from "@/stores/useGameStore";
 import { usePlayerStore } from "@/stores/usePlayerStore";
-import { useMinimapStore } from "@/stores/useMinimapStore";
 import { usePersistenceStore } from "@/stores/usePersistenceStore";
+import { resetSessionStores } from "@/stores/resetSessionStores";
 import { computeRunScore } from "@/types/persistence";
 import { setNextRunSeed } from "@/lib/next-run-seed";
 
@@ -29,14 +29,6 @@ const PIXELS_PER_TILE = 32;
 /** Convert pixel distance to a human-friendly meter string. */
 function formatDistance(pixels: number): string {
   return `${Math.round(pixels / PIXELS_PER_TILE)}m`;
-}
-
-/** Reset all Zustand stores to initial values for a fresh run. */
-function resetAllStores(): void {
-  useUIStore.getState().reset();
-  useGameStore.getState().reset();
-  usePlayerStore.getState().reset();
-  useMinimapStore.getState().reset();
 }
 
 /** Zombie variant display names. */
@@ -126,7 +118,7 @@ export function DeathScreen() {
     hasSaved.current = false;
     setCopied(false);
     try {
-      resetAllStores();
+      resetSessionStores();
       useGameStore.getState().incrementRunKey();
     } catch (err) {
       console.error("[DeathScreen] Failed to restart game:", err);
@@ -139,7 +131,7 @@ export function DeathScreen() {
     setCopied(false);
     try {
       if (seed) setNextRunSeed(seed);
-      resetAllStores();
+      resetSessionStores();
       useGameStore.getState().incrementRunKey();
     } catch (err) {
       console.error("[DeathScreen] Failed to restart with same seed:", err);
@@ -151,7 +143,7 @@ export function DeathScreen() {
     hasSaved.current = false;
     setCopied(false);
     try {
-      resetAllStores();
+      resetSessionStores();
       router.push("/");
     } catch (err) {
       console.error("[DeathScreen] Failed to return to menu:", err);

--- a/src/components/game-container.test.tsx
+++ b/src/components/game-container.test.tsx
@@ -29,6 +29,10 @@ vi.mock("@/lib/bridge", () => ({
 }));
 
 import GameContainer from "@/components/game-container";
+import { useGameStore } from "@/stores/useGameStore";
+import { usePlayerStore } from "@/stores/usePlayerStore";
+import { useUIStore } from "@/stores/useUIStore";
+import { useMinimapStore } from "@/stores/useMinimapStore";
 
 /** Minimal error boundary for testing the throw-on-render path. */
 class TestErrorBoundary extends React.Component<
@@ -336,4 +340,34 @@ test("throws to error boundary when runtime crash detected after bridge connects
   );
 
   consoleSpy.mockRestore();
+});
+
+test("resets all session stores on unmount", async () => {
+  vi.useFakeTimers();
+  const fakeBus = { on: vi.fn(), off: vi.fn(), listeners: vi.fn().mockReturnValue([]) };
+  mockGetActiveBus.mockReturnValue(fakeBus);
+  mockConnectBridge.mockReturnValue({ disconnect: mockDisconnect });
+
+  // Set stale data in all session stores
+  useGameStore.setState({ totalKills: 42 });
+  usePlayerStore.setState({ health: 25, alive: false });
+  useUIStore.setState({ activeMenu: "death" as const });
+  useMinimapStore.setState({ playerPosition: { x: 100, y: 200 } });
+
+  const { unmount } = render(<GameContainer />);
+
+  // Wait for bridge to connect
+  await vi.advanceTimersByTimeAsync(20);
+  await vi.waitFor(() => {
+    expect(mockConnectBridge).toHaveBeenCalled();
+  });
+
+  unmount();
+
+  // All session stores should be reset to initial values
+  expect(useGameStore.getState().totalKills).toBe(0);
+  expect(usePlayerStore.getState().health).toBe(100);
+  expect(usePlayerStore.getState().alive).toBe(true);
+  expect(useUIStore.getState().activeMenu).toBe("none");
+  expect(useMinimapStore.getState().playerPosition).toEqual({ x: 0, y: 0 });
 });

--- a/src/components/game-container.tsx
+++ b/src/components/game-container.tsx
@@ -6,6 +6,7 @@ import { safeEmit } from "@/game/events/event-bus";
 import { useGameStore } from "@/stores/useGameStore";
 import { useMinimapStore } from "@/stores/useMinimapStore";
 import { useSettingsStore } from "@/stores/useSettingsStore";
+import { resetSessionStores } from "@/stores/resetSessionStores";
 
 export default function GameContainer() {
   const [error, setError] = useState<Error | null>(null);
@@ -105,7 +106,7 @@ export default function GameContainer() {
     return () => {
       cancelled = true;
       bridge?.disconnect();
-      useMinimapStore.getState().reset();
+      resetSessionStores();
       destroy?.();
     };
   }, []);

--- a/src/components/pause-menu.tsx
+++ b/src/components/pause-menu.tsx
@@ -16,20 +16,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useUIStore } from "@/stores/useUIStore";
 import { useGameStore } from "@/stores/useGameStore";
-import { usePlayerStore } from "@/stores/usePlayerStore";
-import { useMinimapStore } from "@/stores/useMinimapStore";
+import { resetSessionStores } from "@/stores/resetSessionStores";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Reset all Zustand stores to initial values for a fresh run. */
-function resetAllStores(): void {
-  useUIStore.getState().reset();
-  useGameStore.getState().reset();
-  usePlayerStore.getState().reset();
-  useMinimapStore.getState().reset();
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -61,7 +52,7 @@ export function PauseMenu() {
 
   const handleAbandonConfirm = useCallback(() => {
     try {
-      resetAllStores();
+      resetSessionStores();
       router.push("/");
     } catch (err) {
       console.error("[PauseMenu] Failed to abandon run:", err);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -26,3 +26,19 @@ export type { SettingsStoreActions } from "./useSettingsStore";
 // Persistence (IndexedDB — run history, leaderboard, lifetime stats)
 export { usePersistenceStore } from "./usePersistenceStore";
 export type { PersistenceStoreState, PersistenceStoreActions } from "./usePersistenceStore";
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Reset all session-scoped Zustand stores to initial values.
+ *
+ * Call when a game session ends — on unmount, death-screen actions,
+ * or pause-menu abandon.  Does NOT reset settings or persistence stores
+ * (those survive across sessions).
+ *
+ * Important: disconnect the bridge BEFORE calling this to avoid
+ * spurious cmd:resume events from the paused subscription.
+ */
+export { resetSessionStores } from "./resetSessionStores";

--- a/src/stores/resetSessionStores.ts
+++ b/src/stores/resetSessionStores.ts
@@ -1,0 +1,22 @@
+/**
+ * Reset all session-scoped Zustand stores to initial values.
+ *
+ * Call when a game session ends — on unmount, death-screen actions,
+ * or pause-menu abandon.  Does NOT reset settings or persistence stores
+ * (those survive across sessions).
+ *
+ * Important: disconnect the bridge BEFORE calling this to avoid
+ * spurious cmd:resume events from the paused subscription.
+ */
+
+import { useUIStore } from "./useUIStore";
+import { useGameStore } from "./useGameStore";
+import { usePlayerStore } from "./usePlayerStore";
+import { useMinimapStore } from "./useMinimapStore";
+
+export function resetSessionStores(): void {
+  useUIStore.getState().reset();
+  useGameStore.getState().reset();
+  usePlayerStore.getState().reset();
+  useMinimapStore.getState().reset();
+}


### PR DESCRIPTION
## Summary
- Extracts shared `resetSessionStores()` function that resets UIStore, GameStore, PlayerStore, and MinimapStore (excludes Settings and Persistence — they survive across sessions)
- Calls `resetSessionStores()` in GameContainer cleanup after bridge disconnect, before Phaser destroy
- Replaces duplicated `resetAllStores()` helpers in death-screen and pause-menu with the shared function
- Prevents stale HUD data (health, kills, phase) from flashing when returning to `/play` within the same SPA session

Resolves #70

## Review
Reviewed by the Forge Temperer. Cleanup ordering verified (disconnect → reset → destroy). DRY extraction confirmed. All tests pass (2067/2067).

🤖 Generated with [Claude Code](https://claude.com/claude-code)