### PR TITLE
Guard connectBridge call against synchronous exceptions

### DIFF
--- a/src/components/game-container.test.tsx
+++ b/src/components/game-container.test.tsx
@@ -208,6 +208,39 @@ test("connects bridge when getActiveBus returns a bus", async () => {
   expect(mockConnectBridge).toHaveBeenCalledWith(fakeBus);
 });
 
+test("throws to error boundary when connectBridge throws", async () => {
+  vi.useFakeTimers();
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const fakeBus = { on: vi.fn(), off: vi.fn(), listeners: vi.fn().mockReturnValue([]) };
+  mockGetActiveBus.mockReturnValue(fakeBus);
+
+  // Make connectBridge throw to simulate bridge initialization failure
+  mockConnectBridge.mockImplementation(() => {
+    throw new Error("bridge init failed");
+  });
+
+  render(
+    <TestErrorBoundary>
+      <GameContainer />
+    </TestErrorBoundary>,
+  );
+
+  // Flush dynamic import + first rAF poll
+  await vi.advanceTimersByTimeAsync(20);
+
+  await vi.waitFor(() => {
+    expect(screen.getByTestId("boundary-error")).toBeInTheDocument();
+  });
+  expect(screen.getByTestId("boundary-error").textContent).toBe(
+    "bridge init failed",
+  );
+
+  // Bridge never connected, so disconnect should not be called
+  expect(mockDisconnect).not.toHaveBeenCalled();
+
+  consoleSpy.mockRestore();
+});
+
 test("disconnects bridge on unmount after successful connection", async () => {
   vi.useFakeTimers();
   const fakeBus = { on: vi.fn(), off: vi.fn(), listeners: vi.fn().mockReturnValue([]) };

--- a/src/components/game-container.tsx
+++ b/src/components/game-container.tsx
@@ -43,46 +43,53 @@ export default function GameContainer() {
 
           const bus = getActiveBus();
           if (bus) {
-            bridge = connectBridge(bus);
-            // Pull seed and minimap init from PhaserGame module — these events
-            // fired before the bridge connected, so we read them directly.
-            const seed = getActiveSeed();
-            if (seed) {
-              useGameStore.getState().setSeed(seed);
-            }
-            const minimapInit = getActiveMinimapInit();
-            if (minimapInit) {
-              useMinimapStore.getState().setMapBounds(
-                minimapInit.mapWidth,
-                minimapInit.mapHeight,
-                minimapInit.safehouseCenter,
-              );
-            }
-            // Push current settings to game systems on connect
-            const SETTINGS_KEYS = [
-              "masterVolume", "sfxVolume", "musicVolume",
-              "screenShake", "showFps", "graphicsQuality",
-              "colorBlindMode", "reducedMotion", "highContrast",
-            ] as const;
-            const settings = useSettingsStore.getState();
-            for (const key of SETTINGS_KEYS) {
-              safeEmit(bus, "cmd:settings-changed", { key, value: settings[key] });
-            }
-
-            // Poll for runtime crashes after the bridge connects.
-            // The tryConnect loop has stopped, so runtime errors (game-crash)
-            // need a separate polling path.  One variable read per frame.
-            const pollCrash = () => {
-              if (cancelled) return;
-              const crashError = getActiveError();
-              if (crashError) {
-                console.error("[GameContainer] Game runtime crash:", crashError);
-                setError(crashError);
-                return;
+            try {
+              bridge = connectBridge(bus);
+              // Pull seed and minimap init from PhaserGame module — these events
+              // fired before the bridge connected, so we read them directly.
+              const seed = getActiveSeed();
+              if (seed) {
+                useGameStore.getState().setSeed(seed);
               }
+              const minimapInit = getActiveMinimapInit();
+              if (minimapInit) {
+                useMinimapStore.getState().setMapBounds(
+                  minimapInit.mapWidth,
+                  minimapInit.mapHeight,
+                  minimapInit.safehouseCenter,
+                );
+              }
+              // Push current settings to game systems on connect
+              const SETTINGS_KEYS = [
+                "masterVolume", "sfxVolume", "musicVolume",
+                "screenShake", "showFps", "graphicsQuality",
+                "colorBlindMode", "reducedMotion", "highContrast",
+              ] as const;
+              const settings = useSettingsStore.getState();
+              for (const key of SETTINGS_KEYS) {
+                safeEmit(bus, "cmd:settings-changed", { key, value: settings[key] });
+              }
+
+              // Poll for runtime crashes after the bridge connects.
+              // The tryConnect loop has stopped, so runtime errors (game-crash)
+              // need a separate polling path.  One variable read per frame.
+              const pollCrash = () => {
+                if (cancelled) return;
+                const crashError = getActiveError();
+                if (crashError) {
+                  console.error("[GameContainer] Game runtime crash:", crashError);
+                  setError(crashError);
+                  return;
+                }
+                requestAnimationFrame(pollCrash);
+              };
               requestAnimationFrame(pollCrash);
-            };
-            requestAnimationFrame(pollCrash);
+            } catch (err) {
+              const e = err instanceof Error ? err : new Error(String(err));
+              console.error("[GameContainer] Bridge connection failed:", e);
+              setError(e);
+              return;
+            }
           } else if (retries++ < MAX_BRIDGE_RETRIES) {
             requestAnimationFrame(tryConnect);
           } else {


### PR DESCRIPTION
## Summary
- Wraps the entire bridge connection block in GameContainer's `tryConnect` callback with a try-catch
- Guards `connectBridge(bus)`, seed/minimap pulling, settings push, and pollCrash setup against synchronous exceptions
- On catch: coerces error, logs, calls `setError()`, and returns — surfaces failure to the error boundary instead of silently producing a half-working game

Resolves #72

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified. Error handling consistent with existing patterns. All tests pass (2073/2073).

🤖 Generated with [Claude Code](https://claude.com/claude-code)