### PR TITLE
Use Matter.Body API methods instead of direct property mutation

### DIFF
--- a/src/game/__mocks__/phaser.ts
+++ b/src/game/__mocks__/phaser.ts
@@ -21,6 +21,7 @@ class MockScene {
   }
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 const Phaser = {
   AUTO: 0,
   HEADLESS: 3,
@@ -28,6 +29,33 @@ const Phaser = {
   Scale: {
     FIT: 1,
     CENTER_BOTH: 3,
+  },
+  Physics: {
+    Matter: {
+      Matter: {
+        Body: {
+          setPosition(body: any, position: { x: number; y: number }) {
+            body.position.x = position.x;
+            body.position.y = position.y;
+          },
+          setVelocity(body: any, velocity: { x: number; y: number }) {
+            body.velocity.x = velocity.x;
+            body.velocity.y = velocity.y;
+            body.speed = Math.sqrt(velocity.x ** 2 + velocity.y ** 2);
+          },
+          setAngularVelocity(body: any, velocity: number) {
+            body.angularVelocity = velocity;
+          },
+          setStatic(body: any, isStatic: boolean) {
+            body.isStatic = isStatic;
+          },
+          setInertia(body: any, inertia: number) {
+            body.inertia = inertia;
+            body.inverseInertia = inertia === Infinity ? 0 : 1 / inertia;
+          },
+        },
+      },
+    },
   },
   Game: class MockGame {
     config: unknown;

--- a/src/game/ecs/sensor-pool.ts
+++ b/src/game/ecs/sensor-pool.ts
@@ -9,6 +9,7 @@
  */
 
 import type { BodyRegistry } from "@/game/systems/body-registry";
+import { setBodyPosition } from "@/game/physics/matter-body";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,8 +79,7 @@ export class SensorBodyPool {
     }
 
     // Reposition and activate
-    body.position.x = x;
-    body.position.y = y;
+    setBodyPosition(body, { x, y });
     // Sensor bodies are always static + sensor (that's their normal mode)
     // Just make sure they're visible to collision detection
     this.bodyRegistry.register(body);
@@ -100,8 +100,7 @@ export class SensorBodyPool {
     this.bodyRegistry.unregister(body.id);
 
     // Move off-screen
-    body.position.x = -9999;
-    body.position.y = -9999;
+    setBodyPosition(body, { x: -9999, y: -9999 });
 
     this.activeSet.delete(body);
     this.dormant.push(body);

--- a/src/game/ecs/zombie-pool.ts
+++ b/src/game/ecs/zombie-pool.ts
@@ -20,6 +20,11 @@ import {
   SHAMBLER_HEALTH,
 } from "@/game/systems/zombie-ai-constants";
 import { EntityPool } from "./pool";
+import {
+  setBodyPosition,
+  setBodyStatic,
+  setBodyInertia,
+} from "@/game/physics/matter-body";
 
 // ---------------------------------------------------------------------------
 // Sprite key mapping (duplicated from archetypes.ts to avoid circular dep)
@@ -104,8 +109,7 @@ export function createZombiePool(
       isStatic: true,    // Sleeping: static + sensor
       isSensor: true,
     });
-    body.inertia = Infinity;
-    body.inverseInertia = 0;
+    setBodyInertia(body, Infinity);
 
     // Build the entity object (NOT added to world — pool handles that)
     const entity: ZombieEntity = {
@@ -163,8 +167,8 @@ export function createZombiePool(
     // Wake the body and register it
     const body = bodyMap.get(entity);
     if (body) {
-      body.isStatic = false;
-      body.isSensor = false;
+      setBodyStatic(body, false);
+      body.isSensor = false; // No Matter.js API for isSensor
       bodyRegistry.register(body);
     }
   }
@@ -221,9 +225,7 @@ export function configureZombie(
   // Reposition and resize the Matter.js body
   const body = bodyMap.get(entity);
   if (body) {
-    // Matter.js Body.setPosition equivalent
-    body.position.x = x;
-    body.position.y = y;
+    setBodyPosition(body, { x, y });
     // Update body bounds for the variant's size (Matter.js vertices aren't
     // easily resizable, but since all variants use similar-sized rectangles
     // and we're using placeholder graphics, the base shambler body works
@@ -247,11 +249,10 @@ export function releaseZombie(
   const body = bodyMap.get(entity);
   if (body) {
     bodyRegistry.unregister(body.id);
-    body.isStatic = true;
-    body.isSensor = true;
+    setBodyStatic(body, true);
+    body.isSensor = true; // No Matter.js API for isSensor
     // Move off-screen to avoid stale collision
-    body.position.x = -9999;
-    body.position.y = -9999;
+    setBodyPosition(body, { x: -9999, y: -9999 });
   }
 
   pool.release(entity);

--- a/src/game/physics/matter-body.ts
+++ b/src/game/physics/matter-body.ts
@@ -1,0 +1,57 @@
+/**
+ * Re-export Matter.Body static methods from Phaser's bundled Matter.js.
+ *
+ * Use these instead of mutating body properties directly — direct mutation
+ * bypasses Matter.js internal bookkeeping (broadphase AABB updates,
+ * sleeping state, constraint warmstarting).
+ *
+ * Centralises the Phaser import so individual systems and pools stay
+ * decoupled from the Phaser module.
+ *
+ * NO React imports — this is pure TypeScript.
+ */
+
+import Phaser from "phaser";
+
+// Phaser bundles Matter.js and exposes it at runtime as
+// Phaser.Physics.Matter.Matter.  The TypeScript definitions for this
+// path vary across Phaser versions, so we access it dynamically and
+// lean on the globally-declared MatterJS.Body type for call-site safety.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Body: typeof MatterJS.Body = (Phaser.Physics.Matter as any).Matter.Body;
+
+export function setBodyPosition(
+  body: MatterJS.BodyType,
+  position: { x: number; y: number },
+  updateVelocity?: boolean,
+): void {
+  Body.setPosition(body, position, updateVelocity);
+}
+
+export function setBodyVelocity(
+  body: MatterJS.BodyType,
+  velocity: { x: number; y: number },
+): void {
+  Body.setVelocity(body, velocity);
+}
+
+export function setBodyAngularVelocity(
+  body: MatterJS.BodyType,
+  velocity: number,
+): void {
+  Body.setAngularVelocity(body, velocity);
+}
+
+export function setBodyStatic(
+  body: MatterJS.BodyType,
+  isStatic: boolean,
+): void {
+  Body.setStatic(body, isStatic);
+}
+
+export function setBodyInertia(
+  body: MatterJS.BodyType,
+  inertia: number,
+): void {
+  Body.setInertia(body, inertia);
+}

--- a/src/game/scenes/game-scene.ts
+++ b/src/game/scenes/game-scene.ts
@@ -37,6 +37,7 @@ import { SensorBodyPool } from "@/game/ecs/sensor-pool";
 import { COMBAT } from "@/game/systems/combat-constants";
 import { createGameEventBus, safeEmit } from "@/game/events/event-bus";
 import { setActiveBus, setActiveSeed, setActiveMinimapInit } from "@/game/PhaserGame";
+import { setBodyInertia } from "@/game/physics/matter-body";
 import { TILE_SIZE, TileType, TILE_PROPERTIES } from "@/game/tiles/tile-types";
 import { TILESET_KEY } from "@/game/tiles/tileset-generator";
 import { getObjectDef } from "@/game/procgen/object-defs";
@@ -114,8 +115,7 @@ export default class GameScene extends Phaser.Scene {
       restitution: 0,
     });
     // Prevent rotation — set inertia after creation (not in MatterBodyConfig)
-    playerBody.inertia = Infinity;
-    playerBody.inverseInertia = 0;
+    setBodyInertia(playerBody, Infinity);
     bodyRegistry.register(playerBody);
     createPlayerEntity(px, py, playerBody.id);
 
@@ -430,8 +430,7 @@ export default class GameScene extends Phaser.Scene {
           restitution: 0.2,
           mass: def.immovable ? def.physics.mass * 10 : def.physics.mass,
         });
-        body.inertia = Infinity;
-        body.inverseInertia = 0;
+        setBodyInertia(body, Infinity);
         bodyRegistry.register(body);
 
         createObjectEntity(

--- a/src/game/systems/barricade-system.ts
+++ b/src/game/systems/barricade-system.ts
@@ -23,6 +23,7 @@ import {
   barricadeEntities,
 } from "@/game/ecs/queries";
 import { getObjectDef } from "@/game/procgen/object-defs";
+import { setBodyPosition, setBodyVelocity } from "@/game/physics/matter-body";
 import { safeEmit } from "@/game/events/event-bus";
 import { TILE_SIZE } from "@/game/procgen/constants";
 import { NOISE } from "./noise-constants";
@@ -406,10 +407,8 @@ function tryPlaceBarricade(
   }
 
   // Move object to snap center for clean alignment
-  objectBody.position.x = snapTarget.centerX;
-  objectBody.position.y = snapTarget.centerY;
-  objectBody.velocity.x = 0;
-  objectBody.velocity.y = 0;
+  setBodyPosition(objectBody, { x: snapTarget.centerX, y: snapTarget.centerY });
+  setBodyVelocity(objectBody, { x: 0, y: 0 });
 
   // Resolve anchor bodies
   const anchorA = ctx.bodyRegistry.get(snapTarget.anchorBodyIdA);

--- a/src/game/systems/physics-sync-system.ts
+++ b/src/game/systems/physics-sync-system.ts
@@ -1,6 +1,7 @@
 import type { SystemFn } from "./system-runner";
 import type { SceneContext } from "./scene-context";
 import { movingEntities, physicsBodies } from "@/game/ecs/queries";
+import { setBodyVelocity, setBodyAngularVelocity } from "@/game/physics/matter-body";
 
 /**
  * Factory that returns a PhysicsSyncSystem.
@@ -52,12 +53,8 @@ export function createPhysicsSyncSystem(ctx: SceneContext): SystemFn {
       const stepVx = entity.velocity.vx * dt;
       const stepVy = entity.velocity.vy * dt;
 
-      body.velocity.x = stepVx;
-      body.velocity.y = stepVy;
-
-      // Also update speed/angle fields that some collision checks use
-      body.speed = Math.sqrt(stepVx * stepVx + stepVy * stepVy);
-      body.angularVelocity = 0;
+      setBodyVelocity(body, { x: stepVx, y: stepVy });
+      setBodyAngularVelocity(body, 0);
     }
 
     // 2. Step: advance physics by one fixed timestep (ms)

--- a/src/game/systems/zombie-spawner-utils.ts
+++ b/src/game/systems/zombie-spawner-utils.ts
@@ -21,6 +21,7 @@ import { createZombieEntity, type ZombieEntity } from "@/game/ecs/archetypes";
 import type { BodyRegistry } from "./body-registry";
 import type { EntityPool } from "@/game/ecs/pool";
 import { configureZombie } from "@/game/ecs/zombie-pool";
+import { setBodyInertia } from "@/game/physics/matter-body";
 
 // ---------------------------------------------------------------------------
 // Variant selection
@@ -129,8 +130,7 @@ function createZombieBody(
     frictionAir: 0.05,
     restitution: 0.1,
   });
-  body.inertia = Infinity;
-  body.inverseInertia = 0;
+  setBodyInertia(body as unknown as MatterJS.BodyType, Infinity);
   // SAFETY: bodyRegistry.register stores the body instance in its internal
   // map keyed by body.id. The real Phaser MatterFactory.rectangle returns a
   // full MatterJS.BodyType, but SpawnContext narrows the interface for


### PR DESCRIPTION
## Summary
- Creates centralized `src/game/physics/matter-body.ts` utility with typed wrappers for `setPosition`, `setVelocity`, `setAngularVelocity`, `setStatic`, `setInertia`
- Replaces all direct body property mutations (position, velocity, speed, angularVelocity, isStatic, inertia) with Matter.js API calls across 6 game files
- Eliminates manual `body.speed = Math.sqrt(...)` and `body.inverseInertia = 0` calculations (auto-computed by Matter.js API)
- Correctly preserves direct assignment for `body.isSensor`, `body.force`, `body.friction` (no Matter.js API exists)
- Enhanced Phaser mock with matching `Physics.Matter.Matter.Body` implementations

Resolves #77

## Review
Reviewed by the Forge Temperer. Full codebase audit verified — all properties with API equivalents migrated, exclusions documented. All tests pass (2074/2074).

🤖 Generated with [Claude Code](https://claude.com/claude-code)