### PR TITLE
Fix barricade pathfinding unblock using entry point tile

### DIFF
--- a/src/game/systems/barricade-system.test.ts
+++ b/src/game/systems/barricade-system.test.ts
@@ -784,6 +784,47 @@ describe("BarricadeSystem", () => {
       );
     });
 
+    it("unblocks the entry point tile even when physics body drifts", () => {
+      const { ctx, bodyRegistry, pathfindingGrid, entryPoints } = createMockContext();
+
+      const playerBody = mockBody();
+      bodyRegistry.register(playerBody);
+      createPlayerEntity(100, 100, playerBody.id);
+
+      const epCenterX = 5 * TILE_SIZE + TILE_SIZE / 2;
+      const epCenterY = 3 * TILE_SIZE + TILE_SIZE / 2;
+      const objBody = mockBody(undefined, epCenterX, epCenterY);
+      bodyRegistry.register(objBody);
+      createObjectEntity(
+        epCenterX, epCenterY, objBody.id,
+        "wooden_plank", ObjectCategory.Loot, false,
+        { durability: 0.3, flammability: 0.9, conductivity: 0 }, 3,
+      );
+
+      // Place the barricade
+      ctx.inputState.pointerReleased = true;
+      const system = createBarricadeSystem(ctx);
+      system(1 / 60);
+
+      expect(pathfindingGrid.isWalkable(5, 3)).toBe(false);
+      ctx.inputState.pointerReleased = false;
+
+      // Simulate physics drift — move the entity a full tile away from the
+      // entry point.  With the buggy code this would unblock tile (6,4)
+      // instead of (5,3), leaving the entry point permanently blocked.
+      const barricade = barricadeEntities.entities[0];
+      barricade.position!.x = 6 * TILE_SIZE + TILE_SIZE / 2;
+      barricade.position!.y = 4 * TILE_SIZE + TILE_SIZE / 2;
+
+      // Destroy the barricade
+      barricade.health.current = 0;
+      system(1 / 60);
+
+      // Entry point tile (5,3) must be unblocked, not the drifted position (6,4)
+      expect(pathfindingGrid.isWalkable(5, 3)).toBe(true);
+      expect(entryPoints[0].barricaded).toBe(false);
+    });
+
     it("keeps pathfinding blocked when other barricades remain at entry point", () => {
       const { ctx, bodyRegistry, pathfindingGrid, entryPoints } = createMockContext();
 

--- a/src/game/systems/barricade-system.ts
+++ b/src/game/systems/barricade-system.ts
@@ -310,19 +310,22 @@ export function createBarricadeSystem(ctx: SceneContext): SystemFn {
       );
 
       if (!hasOtherBarricades) {
-        const tileX = pixelToTile(positionCopy.x);
-        const tileY = pixelToTile(positionCopy.y);
-        const updated = pathfindingGrid.setWalkable(tileX, tileY, true);
-        if (!updated) {
-          console.warn(
-            `[BarricadeSystem] Failed to unblock pathfinding at tile (${tileX}, ${tileY}) — out of grid bounds`,
-          );
-        } else {
-          safeEmit(ctx.eventBus, "topology-changed", { tileX, tileY, walkable: true });
-        }
-
-        if (entryPoints[entryPointIndex]) {
-          entryPoints[entryPointIndex].barricaded = false;
+        const ep = entryPoints[entryPointIndex];
+        if (ep) {
+          // Use the entry point's tile coordinate — not the entity's runtime
+          // position — to ensure we unblock the same tile that was blocked
+          // during placement, even if the physics body drifted.
+          const tileX = ep.position.x;
+          const tileY = ep.position.y;
+          const updated = pathfindingGrid.setWalkable(tileX, tileY, true);
+          if (!updated) {
+            console.warn(
+              `[BarricadeSystem] Failed to unblock pathfinding at tile (${tileX}, ${tileY}) — out of grid bounds`,
+            );
+          } else {
+            safeEmit(ctx.eventBus, "topology-changed", { tileX, tileY, walkable: true });
+          }
+          ep.barricaded = false;
         } else {
           console.warn(
             `[BarricadeSystem] Entry point index ${entryPointIndex} out of bounds (${entryPoints.length} entry points)`,

--- a/src/game/systems/explosion-system.ts
+++ b/src/game/systems/explosion-system.ts
@@ -414,12 +414,13 @@ export function createExplosionSystem(ctx: SceneContext): SystemFn {
             );
 
             if (!hasOtherBarricades) {
-              const tileX = pixelToTile(positionCopy.x);
-              const tileY = pixelToTile(positionCopy.y);
-              ctx.pathfindingGrid.setWalkable(tileX, tileY, true);
-
-              if (ctx.entryPoints?.[entryPointIndex]) {
-                ctx.entryPoints[entryPointIndex].barricaded = false;
+              const ep = ctx.entryPoints?.[entryPointIndex];
+              if (ep) {
+                // Use entry point tile coordinate, not drifted entity position
+                const tileX = ep.position.x;
+                const tileY = ep.position.y;
+                ctx.pathfindingGrid.setWalkable(tileX, tileY, true);
+                ep.barricaded = false;
               }
             }
           }

--- a/src/game/systems/fire-system.ts
+++ b/src/game/systems/fire-system.ts
@@ -27,7 +27,6 @@ import {
 import { safeEmit } from "@/game/events/event-bus";
 import { FIRE } from "./fire-constants";
 import { MATERIAL } from "./material-constants";
-import { TILE_SIZE } from "@/game/procgen/constants";
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -58,11 +57,6 @@ function distSq(ax: number, ay: number, bx: number, by: number): number {
 /** Linear interpolation. */
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t;
-}
-
-/** Convert world pixels to tile coordinates. */
-function pixelToTile(px: number): number {
-  return Math.floor(px / TILE_SIZE);
 }
 
 /**
@@ -343,17 +337,18 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
           );
 
           if (!hasOtherBarricades) {
-            const tileX = pixelToTile(positionCopy.x);
-            const tileY = pixelToTile(positionCopy.y);
-            const updated = ctx.pathfindingGrid.setWalkable(tileX, tileY, true);
-            if (!updated) {
-              console.warn(
-                `[FireSystem] Failed to unblock pathfinding at tile (${tileX}, ${tileY}) — out of grid bounds`,
-              );
-            }
-
-            if (ctx.entryPoints?.[entryPointIndex]) {
-              ctx.entryPoints[entryPointIndex].barricaded = false;
+            const ep = ctx.entryPoints?.[entryPointIndex];
+            if (ep) {
+              // Use entry point tile coordinate, not drifted entity position
+              const tileX = ep.position.x;
+              const tileY = ep.position.y;
+              const updated = ctx.pathfindingGrid.setWalkable(tileX, tileY, true);
+              if (!updated) {
+                console.warn(
+                  `[FireSystem] Failed to unblock pathfinding at tile (${tileX}, ${tileY}) — out of grid bounds`,
+                );
+              }
+              ep.barricaded = false;
             }
           }
         }


### PR DESCRIPTION
## Summary
- Fixes barricade destruction pathfinding unblock using runtime entity position instead of entry point tile coordinate across all three destruction paths (barricade-system, fire-system, explosion-system)
- Uses `entryPoints[entryPointIndex].position` (already in tile coordinates) instead of `pixelToTile(positionCopy.x/y)` — eliminates physics drift as a source of error
- Removes dead `pixelToTile` function and `TILE_SIZE` import from fire-system (only used in destruction path)
- Adds regression test: drifts entity position one full tile, verifies entry point tile is correctly unblocked

Resolves #79

## Review
Reviewed by the Forge Temperer. Fix verified across all three destruction paths. Dead code cleanup confirmed correct. Regression test directly reproduces the bug scenario. All tests pass (2075/2075).

🤖 Generated with [Claude Code](https://claude.com/claude-code)