### PR TITLE
Standardize safe removal for Matter.js bodies and constraints

### DIFF
--- a/src/game/systems/barricade-system.ts
+++ b/src/game/systems/barricade-system.ts
@@ -24,6 +24,7 @@ import {
 } from "@/game/ecs/queries";
 import { getObjectDef } from "@/game/procgen/object-defs";
 import { setBodyPosition, setBodyVelocity } from "@/game/physics/matter-body";
+import { safeRemoveConstraint } from "./physics-utils";
 import { safeEmit } from "@/game/events/event-bus";
 import { TILE_SIZE } from "@/game/procgen/constants";
 import { NOISE } from "./noise-constants";
@@ -255,18 +256,12 @@ export function createBarricadeSystem(ctx: SceneContext): SystemFn {
 
       // Remove constraints from Matter.js world
       for (const constraintId of cIds) {
-        const constraint = constraintRegistry.get(constraintId);
-        if (constraint) {
-          try {
-            ctx.scene.matter.world.removeConstraint(constraint);
-          } catch (err) {
-            console.error(
-              `[BarricadeSystem] Failed to remove constraint ${constraintId}:`,
-              err,
-            );
-          }
-          constraintRegistry.unregister(constraintId);
-        }
+        safeRemoveConstraint(
+          ctx.scene.matter.world,
+          constraintRegistry,
+          constraintId,
+          "BarricadeSystem",
+        );
       }
 
       // Remove barricade + health components
@@ -446,18 +441,12 @@ function tryPlaceBarricade(
     );
     // Clean up any partially created constraints
     for (const id of constraintIds) {
-      const c = constraintRegistry.get(id);
-      if (c) {
-        try {
-          ctx.scene.matter.world.removeConstraint(c);
-        } catch (cleanupErr) {
-          console.error(
-            `[BarricadeSystem] Failed to clean up partial constraint ${id}:`,
-            cleanupErr,
-          );
-        }
-        constraintRegistry.unregister(id);
-      }
+      safeRemoveConstraint(
+        ctx.scene.matter.world,
+        constraintRegistry,
+        id,
+        "BarricadeSystem",
+      );
     }
     return;
   }

--- a/src/game/systems/combat-system.ts
+++ b/src/game/systems/combat-system.ts
@@ -23,6 +23,7 @@ import { safeEmit } from "@/game/events/event-bus";
 import { getObjectDef } from "@/game/procgen/object-defs";
 import { getActiveItem } from "./inventory-utils";
 import { COMBAT } from "./combat-constants";
+import { safeRemoveBody } from "./physics-utils";
 import { NOISE } from "./noise-constants";
 
 // ---------------------------------------------------------------------------
@@ -141,18 +142,12 @@ export function createCombatSystem(ctx: SceneContext): SystemFn {
         if (ctx.sensorPool && activeSensorBody) {
           ctx.sensorPool.release(activeSensorBody);
         } else {
-          const sensorBody = ctx.bodyRegistry.get(activeSensorId);
-          if (sensorBody) {
-            try {
-              ctx.scene.matter.world.remove(sensorBody);
-            } catch (err) {
-              console.error(
-                `[CombatSystem] Failed to remove orphan sensor body (id=${activeSensorId}):`,
-                err,
-              );
-            }
-          }
-          ctx.bodyRegistry.unregister(activeSensorId);
+          safeRemoveBody(
+            ctx.scene.matter.world,
+            ctx.bodyRegistry,
+            activeSensorId,
+            "CombatSystem",
+          );
         }
         activeSensorId = null;
         activeSensorBody = null;
@@ -179,18 +174,12 @@ export function createCombatSystem(ctx: SceneContext): SystemFn {
       if (ctx.sensorPool && activeSensorBody) {
         ctx.sensorPool.release(activeSensorBody);
       } else {
-        const sensorBody = ctx.bodyRegistry.get(cs.sensorBodyId);
-        if (sensorBody) {
-          try {
-            ctx.scene.matter.world.remove(sensorBody);
-          } catch (err) {
-            console.error(
-              `[CombatSystem] Failed to remove expired sensor body (id=${cs.sensorBodyId}):`,
-              err,
-            );
-          }
-        }
-        ctx.bodyRegistry.unregister(cs.sensorBodyId);
+        safeRemoveBody(
+          ctx.scene.matter.world,
+          ctx.bodyRegistry,
+          cs.sensorBodyId,
+          "CombatSystem",
+        );
       }
       cs.sensorBodyId = null;
       activeSensorId = null;

--- a/src/game/systems/explosion-system.ts
+++ b/src/game/systems/explosion-system.ts
@@ -38,6 +38,7 @@ import { MATERIAL } from "./material-constants";
 import { NOISE } from "./noise-constants";
 import { TileType } from "@/game/tiles/tile-types";
 import { TILE_SIZE } from "@/game/procgen/constants";
+import { safeRemoveBody, safeRemoveConstraint } from "./physics-utils";
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -389,18 +390,12 @@ export function createExplosionSystem(ctx: SceneContext): SystemFn {
           // Release constraints
           if (ctx.constraintRegistry) {
             for (const constraintId of constraintIds) {
-              const constraint = ctx.constraintRegistry.get(constraintId);
-              if (constraint) {
-                try {
-                  ctx.scene.matter.world.removeConstraint(constraint);
-                } catch (err) {
-                  console.error(
-                    `[ExplosionSystem] Failed to remove constraint ${constraintId}:`,
-                    err,
-                  );
-                }
-                ctx.constraintRegistry.unregister(constraintId);
-              }
+              safeRemoveConstraint(
+                ctx.scene.matter.world,
+                ctx.constraintRegistry,
+                constraintId,
+                "ExplosionSystem",
+              );
             }
           }
 
@@ -427,19 +422,12 @@ export function createExplosionSystem(ctx: SceneContext): SystemFn {
 
           // Remove physics body
           if (barricade.physicsBody) {
-            const bodyId = barricade.physicsBody.bodyId;
-            const body = ctx.bodyRegistry.get(bodyId);
-            if (body) {
-              try {
-                ctx.scene.matter.world.remove(body);
-              } catch (err) {
-                console.error(
-                  `[ExplosionSystem] Failed to remove physics body ${bodyId}:`,
-                  err,
-                );
-              }
-            }
-            ctx.bodyRegistry.unregister(bodyId);
+            safeRemoveBody(
+              ctx.scene.matter.world,
+              ctx.bodyRegistry,
+              barricade.physicsBody.bodyId,
+              "ExplosionSystem",
+            );
           }
 
           // Remove entity from ECS
@@ -552,19 +540,12 @@ export function createExplosionSystem(ctx: SceneContext): SystemFn {
         // ---------------------------------------------------------------
 
         if (entity.physicsBody) {
-          const bodyId = entity.physicsBody.bodyId;
-          const body = ctx.bodyRegistry.get(bodyId);
-          if (body) {
-            try {
-              ctx.scene.matter.world.remove(body);
-            } catch (err) {
-              console.error(
-                `[ExplosionSystem] Failed to remove detonating body ${bodyId}:`,
-                err,
-              );
-            }
-          }
-          ctx.bodyRegistry.unregister(bodyId);
+          safeRemoveBody(
+            ctx.scene.matter.world,
+            ctx.bodyRegistry,
+            entity.physicsBody.bodyId,
+            "ExplosionSystem",
+          );
         }
 
         if (entity.position && entity.material) {

--- a/src/game/systems/fire-system.ts
+++ b/src/game/systems/fire-system.ts
@@ -27,6 +27,7 @@ import {
 import { safeEmit } from "@/game/events/event-bus";
 import { FIRE } from "./fire-constants";
 import { MATERIAL } from "./material-constants";
+import { safeRemoveBody, safeRemoveConstraint } from "./physics-utils";
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -313,18 +314,12 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
         const { constraintIds, entryPointIndex } = entity.barricade;
 
         for (const constraintId of constraintIds) {
-          const constraint = ctx.constraintRegistry.get(constraintId);
-          if (constraint) {
-            try {
-              ctx.scene.matter.world.removeConstraint(constraint);
-            } catch (err) {
-              console.error(
-                `[FireSystem] Failed to remove constraint ${constraintId}:`,
-                err,
-              );
-            }
-            ctx.constraintRegistry.unregister(constraintId);
-          }
+          safeRemoveConstraint(
+            ctx.scene.matter.world,
+            ctx.constraintRegistry,
+            constraintId,
+            "FireSystem",
+          );
         }
 
         // Update pathfinding — only unblock if no other barricades at this entry point
@@ -360,19 +355,12 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
 
       // --- Remove physics body from Matter.js ---
       if (entity.physicsBody) {
-        const bodyId = entity.physicsBody.bodyId;
-        const body = ctx.bodyRegistry.get(bodyId);
-        if (body) {
-          try {
-            ctx.scene.matter.world.remove(body);
-          } catch (err) {
-            console.error(
-              `[FireSystem] Failed to remove physics body ${bodyId}:`,
-              err,
-            );
-          }
-        }
-        ctx.bodyRegistry.unregister(bodyId);
+        safeRemoveBody(
+          ctx.scene.matter.world,
+          ctx.bodyRegistry,
+          entity.physicsBody.bodyId,
+          "FireSystem",
+        );
       }
 
       // --- Remove entity from ECS ---

--- a/src/game/systems/physics-utils.test.ts
+++ b/src/game/systems/physics-utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { safeRemoveBody, safeRemoveConstraint } from "./physics-utils";
+import { BodyRegistry } from "./body-registry";
+import { ConstraintRegistry } from "./constraint-registry";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockWorld() {
+  return {
+    remove: vi.fn(),
+    removeConstraint: vi.fn(),
+  };
+}
+
+function createMockBody(id: number): MatterJS.BodyType {
+  return { id, position: { x: 0, y: 0 } } as unknown as MatterJS.BodyType;
+}
+
+function createMockConstraint(id: number): MatterJS.ConstraintType {
+  return { id } as unknown as MatterJS.ConstraintType;
+}
+
+// ---------------------------------------------------------------------------
+// safeRemoveBody
+// ---------------------------------------------------------------------------
+
+describe("safeRemoveBody", () => {
+  it("removes body and unregisters when body exists", () => {
+    const world = createMockWorld();
+    const registry = new BodyRegistry();
+    const body = createMockBody(42);
+    registry.register(body);
+
+    const result = safeRemoveBody(world, registry, 42, "TestSystem");
+
+    expect(result).toBe(true);
+    expect(world.remove).toHaveBeenCalledWith(body);
+    expect(registry.get(42)).toBeUndefined();
+  });
+
+  it("returns false and still unregisters when body is absent", () => {
+    const world = createMockWorld();
+    const registry = new BodyRegistry();
+
+    const result = safeRemoveBody(world, registry, 999, "TestSystem");
+
+    expect(result).toBe(false);
+    expect(world.remove).not.toHaveBeenCalled();
+  });
+
+  it("catches removal errors, logs, and still unregisters", () => {
+    const world = createMockWorld();
+    world.remove.mockImplementation(() => {
+      throw new Error("physics corruption");
+    });
+    const registry = new BodyRegistry();
+    const body = createMockBody(7);
+    registry.register(body);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = safeRemoveBody(world, registry, 7, "TestSystem");
+
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[TestSystem] Failed to remove physics body 7:",
+      expect.any(Error),
+    );
+    // Body still unregistered despite removal failure
+    expect(registry.get(7)).toBeUndefined();
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// safeRemoveConstraint
+// ---------------------------------------------------------------------------
+
+describe("safeRemoveConstraint", () => {
+  it("removes constraint and unregisters when constraint exists", () => {
+    const world = createMockWorld();
+    const registry = new ConstraintRegistry();
+    const constraint = createMockConstraint(10);
+    registry.register(constraint);
+
+    const result = safeRemoveConstraint(world, registry, 10, "TestSystem");
+
+    expect(result).toBe(true);
+    expect(world.removeConstraint).toHaveBeenCalledWith(constraint);
+    expect(registry.get(10)).toBeUndefined();
+  });
+
+  it("returns false when constraint is absent", () => {
+    const world = createMockWorld();
+    const registry = new ConstraintRegistry();
+
+    const result = safeRemoveConstraint(world, registry, 999, "TestSystem");
+
+    expect(result).toBe(false);
+    expect(world.removeConstraint).not.toHaveBeenCalled();
+  });
+
+  it("catches removal errors, logs, and still unregisters", () => {
+    const world = createMockWorld();
+    world.removeConstraint.mockImplementation(() => {
+      throw new Error("constraint error");
+    });
+    const registry = new ConstraintRegistry();
+    const constraint = createMockConstraint(5);
+    registry.register(constraint);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = safeRemoveConstraint(world, registry, 5, "TestSystem");
+
+    expect(result).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[TestSystem] Failed to remove constraint 5:",
+      expect.any(Error),
+    );
+    expect(registry.get(5)).toBeUndefined();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/game/systems/physics-utils.ts
+++ b/src/game/systems/physics-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Safe wrappers for Matter.js body and constraint removal.
+ *
+ * Every system that removes physics bodies or constraints should use these
+ * helpers instead of calling world.remove / world.removeConstraint directly.
+ * They guarantee that:
+ *   1. The registry lookup is null-safe.
+ *   2. The Matter.js call is wrapped in try-catch to prevent cascading failures.
+ *   3. The registry entry is always cleaned up, even if removal throws.
+ *
+ * NO React imports — this is pure TypeScript.
+ */
+
+import type { BodyRegistry } from "./body-registry";
+import type { ConstraintRegistry } from "./constraint-registry";
+
+// ---------------------------------------------------------------------------
+// Narrowed interfaces (keep this module testable without full Phaser types)
+// ---------------------------------------------------------------------------
+
+/** Minimal Matter world interface for body removal. */
+interface MatterWorldRemoveBody {
+  remove(body: MatterJS.BodyType): void;
+}
+
+/** Minimal Matter world interface for constraint removal. */
+interface MatterWorldRemoveConstraint {
+  removeConstraint(constraint: MatterJS.ConstraintType): void;
+}
+
+// ---------------------------------------------------------------------------
+// Body removal
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely remove a physics body from the Matter.js world and unregister it.
+ *
+ * @returns `true` if the body was successfully removed, `false` if it was
+ *          missing or removal threw.
+ */
+export function safeRemoveBody(
+  world: MatterWorldRemoveBody,
+  bodyRegistry: BodyRegistry,
+  bodyId: number,
+  caller: string,
+): boolean {
+  const body = bodyRegistry.get(bodyId);
+  let success = false;
+
+  if (body) {
+    try {
+      world.remove(body);
+      success = true;
+    } catch (err) {
+      console.error(
+        `[${caller}] Failed to remove physics body ${bodyId}:`,
+        err,
+      );
+    }
+  }
+
+  bodyRegistry.unregister(bodyId);
+  return success;
+}
+
+// ---------------------------------------------------------------------------
+// Constraint removal
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely remove a constraint from the Matter.js world and unregister it.
+ *
+ * @returns `true` if the constraint was successfully removed, `false` if it
+ *          was missing or removal threw.
+ */
+export function safeRemoveConstraint(
+  world: MatterWorldRemoveConstraint,
+  constraintRegistry: ConstraintRegistry,
+  constraintId: number,
+  caller: string,
+): boolean {
+  const constraint = constraintRegistry.get(constraintId);
+  let success = false;
+
+  if (constraint) {
+    try {
+      world.removeConstraint(constraint);
+      success = true;
+    } catch (err) {
+      console.error(
+        `[${caller}] Failed to remove constraint ${constraintId}:`,
+        err,
+      );
+    }
+  }
+
+  constraintRegistry.unregister(constraintId);
+  return success;
+}

--- a/src/game/systems/zombie-ai-system.ts
+++ b/src/game/systems/zombie-ai-system.ts
@@ -41,6 +41,7 @@ import { TILE_SIZE } from "@/game/procgen/constants";
 import { ZOMBIE_AI, PATHFINDING_OPT } from "./zombie-ai-constants";
 import { releaseZombie } from "@/game/ecs/zombie-pool";
 import { FlowField } from "@/game/procgen/flow-field";
+import { safeRemoveBody } from "./physics-utils";
 
 // ---------------------------------------------------------------------------
 // Local type alias
@@ -271,9 +272,12 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
         releaseZombie(ctx.zombiePool, entity as unknown as ZombieEntity, ctx.bodyRegistry);
       } else {
         if (entity.physicsBody) {
-          const body = ctx.bodyRegistry.get(entity.physicsBody.bodyId);
-          if (body) ctx.scene.matter.world.remove(body);
-          ctx.bodyRegistry.unregister(entity.physicsBody.bodyId);
+          safeRemoveBody(
+            ctx.scene.matter.world,
+            ctx.bodyRegistry,
+            entity.physicsBody.bodyId,
+            "ZombieAISystem",
+          );
         }
         world.remove(entity);
       }


### PR DESCRIPTION
## Summary
- Creates `physics-utils.ts` with `safeRemoveBody()` and `safeRemoveConstraint()` utilities that guarantee: null-safe registry lookup, try-catch wrapped Matter.js removal, and registry cleanup even on failure
- Replaces 9 inline try-catch blocks across 5 systems (barricade, combat, explosion, fire, zombie-ai)
- Fixes the one unguarded removal in zombie-ai-system.ts (the primary bug)
- Correctly excludes interaction-system.ts — its try-catch serves pickup atomicity, not error resilience
- 6 new tests covering success, absent body/constraint, and removal error scenarios

Resolves #81

## Review
Reviewed by the Forge Temperer. Full audit verified — all Matter.js removal sites standardized except interaction-system.ts (correctly excluded). No unguarded removal calls remain. All tests pass (2081/2081).

🤖 Generated with [Claude Code](https://claude.com/claude-code)