### PR TITLE
Remove dead ZOMBIE_AI.BODY_SIZE constant

### DIFF
--- a/src/game/systems/zombie-ai-constants.test.ts
+++ b/src/game/systems/zombie-ai-constants.test.ts
@@ -74,13 +74,6 @@ describe("zombie AI constants", () => {
       expect(ZOMBIE_AI.CONVERGENCE_SPREAD).toBeGreaterThan(0);
     });
 
-    it("has positive body size", () => {
-      expect(ZOMBIE_AI.BODY_SIZE).toBeGreaterThan(0);
-    });
-
-    it("has body size smaller than player (24)", () => {
-      expect(ZOMBIE_AI.BODY_SIZE).toBeLessThan(24);
-    });
   });
 
   // -----------------------------------------------------------------------

--- a/src/game/systems/zombie-ai-constants.ts
+++ b/src/game/systems/zombie-ai-constants.ts
@@ -168,12 +168,6 @@ export const ZOMBIE_AI = {
    * target the same barricade.
    */
   CONVERGENCE_SPREAD: 8,
-
-  /**
-   * Size of the zombie physics body (pixels). Slightly smaller than the
-   * player (24) for visual distinction and to allow them to bunch up.
-   */
-  BODY_SIZE: 20,
 } as const;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removes `ZOMBIE_AI.BODY_SIZE` constant (value 20) — dead code superseded by per-variant `bodySize` fields on the `ZombieType` interface
- Removes 2 test assertions that only tested the dead constant
- Eliminates maintenance trap: using the fixed constant instead of per-variant `stats.bodySize` would produce incorrect physics bodies for brutes (28) and horde (14)

Resolves #83

## Review
Reviewed by the Forge Temperer. Zero `BODY_SIZE` references remain in `src/`. All tests pass (2079/2079).

🤖 Generated with [Claude Code](https://claude.com/claude-code)