### PR TITLE
Emit wave-ended on error recovery and add per-spawn try-catch

### DIFF
--- a/src/game/systems/wave-system.test.ts
+++ b/src/game/systems/wave-system.test.ts
@@ -836,6 +836,105 @@ describe("WaveSystem", () => {
 
       consoleError.mockRestore();
     });
+
+    it("emits wave-ended when tick error occurs during active wave", () => {
+      const endedHandler = vi.fn();
+      eventBus.on("wave-ended", endedHandler);
+
+      // Start a wave normally
+      setPhase(clockState, "dusk");
+      system(DT);
+      setPhase(clockState, "night");
+      system(DT);
+
+      // Spawn some zombies
+      tickSeconds(system, 2);
+      expect(zombieEntities.entities.length).toBeGreaterThan(0);
+
+      // Sabotage the tickInternal by corrupting clockState to cause a throw
+      // in a way that bypasses the per-spawn catch (e.g., corrupt nightConfig
+      // by making the system access a null property).
+      Object.defineProperty(clockState, "phase", {
+        get() { throw new Error("test tick error"); },
+        configurable: true,
+      });
+
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      system(DT);
+
+      expect(endedHandler).toHaveBeenCalledTimes(1);
+      const event = endedHandler.mock.calls[0][0] as WaveEndedEvent;
+      expect(event.waveNumber).toBe(1);
+      expect(event.dayNumber).toBe(1);
+
+      consoleError.mockRestore();
+      // Restore phase property for afterEach cleanup
+      Object.defineProperty(clockState, "phase", {
+        value: "night",
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("does NOT emit wave-ended when error occurs before wave starts", () => {
+      const mock = createMockContext();
+      const endedHandler = vi.fn();
+      mock.eventBus.on("wave-ended", endedHandler);
+
+      // Sabotage context so prepareNight throws (during "preparing" state)
+      Object.defineProperty(mock.ctx, "spawnZones", {
+        get() { throw new Error("test zones error"); },
+        configurable: true,
+      });
+      const errorSystem = createWaveSystem(mock.ctx);
+
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mock.clockState.phase = "dusk" as const;
+      errorSystem(DT);
+
+      // wave-ended should NOT have been emitted (no wave was started)
+      expect(endedHandler).not.toHaveBeenCalled();
+
+      consoleError.mockRestore();
+    });
+
+    it("continues wave when individual spawn fails", () => {
+      // Start a wave
+      setPhase(clockState, "dusk");
+      system(DT);
+      setPhase(clockState, "night");
+      system(DT);
+
+      // Spawn some zombies normally
+      tickSeconds(system, 1);
+      const countBefore = zombieEntities.entities.length;
+      expect(countBefore).toBeGreaterThan(0);
+
+      // Sabotage one spawn — make rectangle throw once then restore
+      const matterAdd = (ctx.scene as unknown as { matter: { add: { rectangle: (...args: unknown[]) => unknown } } }).matter.add;
+      const originalRect = matterAdd.rectangle;
+      let throwCount = 0;
+      matterAdd.rectangle = (...args: unknown[]) => {
+        if (throwCount++ < 1) {
+          throw new Error("transient spawn failure");
+        }
+        return originalRect(...args);
+      };
+
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Continue ticking — wave should survive the single failed spawn
+      tickSeconds(system, 5);
+      const countAfter = zombieEntities.entities.length;
+
+      // Should have spawned more zombies despite one failure
+      expect(countAfter).toBeGreaterThan(countBefore);
+
+      consoleError.mockRestore();
+      // Restore
+      matterAdd.rectangle = originalRect;
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/src/game/systems/wave-system.ts
+++ b/src/game/systems/wave-system.ts
@@ -310,21 +310,32 @@ export function createWaveSystem(ctx: SceneContext): SystemFn {
     const px = point.x * TILE_SIZE + TILE_SIZE / 2;
     const py = point.y * TILE_SIZE + TILE_SIZE / 2;
 
-    // Spawn entity (or cluster) and collect into a uniform array
-    const spawned =
-      variant === "horde"
-        ? spawnHordeCluster(sCtx, px, py, rng, totalSpawned)
-        : [spawnZombie(sCtx, variant, px, py, totalSpawned)];
+    // Spawn entity (or cluster).  Per-spawn try-catch ensures a single
+    // spawn failure doesn't kill the entire wave.
+    try {
+      const spawned =
+        variant === "horde"
+          ? spawnHordeCluster(sCtx, px, py, rng, totalSpawned)
+          : [spawnZombie(sCtx, variant, px, py, totalSpawned)];
 
-    // Apply stat scaling for night 4+
-    if (nightConfig.statMultiplier !== 1.0) {
-      for (const entity of spawned) {
-        applyStatMultiplier(entity, nightConfig.statMultiplier);
+      // Apply stat scaling for night 4+
+      if (nightConfig.statMultiplier !== 1.0) {
+        for (const entity of spawned) {
+          applyStatMultiplier(entity, nightConfig.statMultiplier);
+        }
       }
-    }
 
-    totalSpawned += spawned.length;
-    spawnedInPulse += spawned.length;
+      totalSpawned += spawned.length;
+      spawnedInPulse += spawned.length;
+    } catch (err) {
+      console.error(
+        `[wave-system] Spawn failed (variant=${variant}, wave=${waveNumber}):`,
+        err,
+      );
+      // Count the failed spawn to prevent infinite retry loops
+      totalSpawned += 1;
+      spawnedInPulse += 1;
+    }
 
     // Advance to next spawn point
     spawnPointIndex++;
@@ -379,6 +390,15 @@ export function createWaveSystem(ctx: SceneContext): SystemFn {
           `spawned=${totalSpawned}/${totalToSpawn}, day=${clockState.dayNumber}):`,
         err,
       );
+      // Emit wave-ended if a wave was actively running, so the bridge
+      // clears waveActive in the Zustand store (prevents stale HUD).
+      if (state === "spawning" || state === "pausing" || state === "complete") {
+        safeEmit(ctx.eventBus, "wave-ended", {
+          waveNumber,
+          zombiesKilled: killsDuringWave,
+          dayNumber: clockState.dayNumber,
+        });
+      }
       // Fail safe: transition to inactive to prevent repeated crashes
       state = "inactive";
       nightConfig = null;


### PR DESCRIPTION
## Summary
- Adds per-spawn try-catch in `spawnNextZombie()` so individual spawn failures don't kill the entire wave — failed spawns are counted to prevent infinite retry loops
- Adds conditional `wave-ended` emission in the tick-level catch block when a wave is actively running (`spawning`, `pausing`, `complete` states), preventing stale `waveActive: true` in the Zustand store
- Guards against emitting `wave-ended` during `preparing`/`inactive` states where no `wave-started` was emitted

Resolves #85

## Review
Reviewed by the Forge Temperer. Error payload matches normal `endWave()` function. State guard is correct. All tests pass (2082/2082).

🤖 Generated with [Claude Code](https://claude.com/claude-code)