### PR TITLE
Guard player-died emission to fire exactly once

### DIFF
--- a/src/game/systems/zombie-ai-system.test.ts
+++ b/src/game/systems/zombie-ai-system.test.ts
@@ -544,6 +544,28 @@ describe("ZombieAISystem", () => {
       expect(diedEvents.length).toBe(1);
       expect(diedEvents[0].cause).toBe("zombie");
     });
+
+    it("emits player-died exactly once when multiple zombies attack in the same tick", () => {
+      const diedEvents: Array<{ cause: string }> = [];
+      ctx.eventBus.on("player-died", (e) => {
+        diedEvents.push({ cause: e.cause });
+      });
+
+      const pPos = tileCenter(3, 3);
+      const player = createPlayerEntity(pPos.x, pPos.y, 10);
+      player.health.current = 1; // One hit will kill
+
+      // Two zombies both in attack range
+      const offset = ZOMBIE_AI.ATTACK_RANGE * 0.5;
+      createZombieEntity(pPos.x + offset, pPos.y, 2);
+      createZombieEntity(pPos.x - offset, pPos.y, 3);
+
+      system(DT); // idle → attacking
+      system(DT); // both attack — only one should emit player-died
+
+      expect(player.health.current).toBe(0);
+      expect(diedEvents.length).toBe(1);
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/src/game/systems/zombie-ai-system.ts
+++ b/src/game/systems/zombie-ai-system.ts
@@ -637,7 +637,7 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
             delta: actualDelta,
           });
 
-          if (targetEntity.health.current <= 0) {
+          if (targetEntity.health.current <= 0 && prevHealth > 0) {
             safeEmit(ctx.eventBus, "player-died", {
               dayNumber: ctx.clockState.dayNumber,
               totalKills,


### PR DESCRIPTION
## Summary
- Adds `&& prevHealth > 0` guard to the `player-died` emission condition in zombie-ai-system.ts
- Ensures the event fires exactly once — on the attack that transitions health from positive to zero
- Prevents redundant events when multiple zombies attack a dead player in the same tick
- Regression test: two zombies attack a 1-HP player simultaneously, verifies exactly one `player-died` event

Resolves #88

## Review
Reviewed by the Forge Temperer. `prevHealth` scope verified (line 626, captures pre-damage health). Guard is correct. All tests pass (2083/2083).

🤖 Generated with [Claude Code](https://claude.com/claude-code)