### PR TITLE
Filter stale collision pairs by isActive in MaterialSystem

### DIFF
--- a/src/game/systems/material-system.test.ts
+++ b/src/game/systems/material-system.test.ts
@@ -22,7 +22,7 @@ const DT = 1 / 60;
 let nextBodyId = 1000;
 
 /** Collision pairs accumulated by the mock Matter.js world. */
-let mockPairs: Array<{ bodyA: { id: number }; bodyB: { id: number } }> = [];
+let mockPairs: Array<{ bodyA: { id: number }; bodyB: { id: number }; isActive?: boolean }> = [];
 
 function createMockContext(
   overrides: Partial<SceneContext> = {},
@@ -449,7 +449,7 @@ describe("MaterialRegistry adjacency", () => {
 
     // Simulate collision pair between their bodies
     mockPairs = [
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
@@ -468,7 +468,7 @@ describe("MaterialRegistry adjacency", () => {
     const plank = spawnWoodenPlank(ctx, 132, 100);
 
     mockPairs = [
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
@@ -503,7 +503,7 @@ describe("MaterialRegistry adjacency", () => {
     // Non-material body (e.g., wall, sensor)
     const wallBodyId = 9999;
     mockPairs = [
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: wallBodyId } },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: wallBodyId }, isActive: true },
     ];
 
     system(DT);
@@ -529,8 +529,8 @@ describe("MaterialRegistry.getConductiveNeighbors", () => {
 
     // Wire touches both metal and plank
     mockPairs = [
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId } },
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
@@ -668,7 +668,7 @@ describe("MaterialRegistry after entity removal", () => {
     const metal = spawnMetalSheet(ctx, 110, 100);
 
     mockPairs = [
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId } },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
@@ -825,7 +825,7 @@ describe("MaterialRegistry adjacency edge cases", () => {
 
     // Tick 1: bodies colliding
     mockPairs = [
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
     ];
     system(DT);
     expect(reg.getAdjacentEntities(gasCan.physicsBody.bodyId)).toHaveLength(1);
@@ -850,9 +850,9 @@ describe("MaterialRegistry adjacency edge cases", () => {
 
     // Wire touches all three other entities simultaneously
     mockPairs = [
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId } },
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
-      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: gasCan.physicsBody.bodyId } },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: wire.physicsBody.bodyId }, bodyB: { id: gasCan.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
@@ -878,15 +878,38 @@ describe("MaterialRegistry adjacency edge cases", () => {
 
     // Same pair reported multiple times (and in both directions)
     mockPairs = [
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
-      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId } },
-      { bodyA: { id: plank.physicsBody.bodyId }, bodyB: { id: gasCan.physicsBody.bodyId } },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: plank.physicsBody.bodyId }, bodyB: { id: gasCan.physicsBody.bodyId }, isActive: true },
     ];
 
     system(DT);
 
     expect(reg.getAdjacentEntities(gasCan.physicsBody.bodyId)).toHaveLength(1);
     expect(reg.getAdjacentEntities(plank.physicsBody.bodyId)).toHaveLength(1);
+  });
+
+  it("excludes stale (inactive) collision pairs from adjacency", () => {
+    const ctx = createMockContext();
+    const system = createMaterialSystem(ctx);
+    const reg = ctx.materialRegistry!;
+
+    const gasCan = spawnGasCan(ctx, 100, 100);
+    const plank = spawnWoodenPlank(ctx, 132, 100);
+    const metal = spawnMetalSheet(ctx, 164, 100);
+
+    // gas_can <-> plank is active, plank <-> metal is stale (isActive: false)
+    mockPairs = [
+      { bodyA: { id: gasCan.physicsBody.bodyId }, bodyB: { id: plank.physicsBody.bodyId }, isActive: true },
+      { bodyA: { id: plank.physicsBody.bodyId }, bodyB: { id: metal.physicsBody.bodyId }, isActive: false },
+    ];
+
+    system(DT);
+
+    // Only the active pair should create adjacency
+    expect(reg.getAdjacentEntities(gasCan.physicsBody.bodyId)).toHaveLength(1);
+    expect(reg.getAdjacentEntities(plank.physicsBody.bodyId)).toHaveLength(1);
+    expect(reg.getAdjacentEntities(metal.physicsBody.bodyId)).toHaveLength(0);
   });
 });
 

--- a/src/game/systems/material-system.ts
+++ b/src/game/systems/material-system.ts
@@ -290,9 +290,9 @@ export function createMaterialSystem(ctx: SceneContext): SystemFn {
     registry.rebuildBodyLookup();
 
     // 2. Update adjacency from Matter.js collision pairs
-    // Phaser wraps Matter.js — access the engine's active pair list.
-    // The pairs.list array contains all pairs that had active collisions
-    // during the last Matter.js step.
+    // Phaser wraps Matter.js — access the engine's pair cache.
+    // pairs.list is the full cache (may include stale separated pairs),
+    // so we filter to isActive pairs only for current-tick adjacency.
     // Use optional chaining because the engine structure may not be fully
     // available in test mocks or before the first physics step.
     const matterWorld = ctx.scene.matter.world as unknown as Record<string, unknown>;
@@ -305,8 +305,9 @@ export function createMaterialSystem(ctx: SceneContext): SystemFn {
       warnedMissingEngine = true;
     }
 
-    const pairs = engine?.pairs?.list ?? [];
-    registry.updateAdjacency(pairs);
+    const allPairs = engine?.pairs?.list ?? [];
+    const activePairs = allPairs.filter((p) => p.isActive);
+    registry.updateAdjacency(activePairs);
   };
 }
 
@@ -317,6 +318,10 @@ export function createMaterialSystem(ctx: SceneContext): SystemFn {
  */
 interface MatterEngine {
   pairs?: {
-    list: ReadonlyArray<{ bodyA: { id: number }; bodyB: { id: number } }>;
+    list: ReadonlyArray<{
+      bodyA: { id: number };
+      bodyB: { id: number };
+      isActive?: boolean;
+    }>;
   };
 }


### PR DESCRIPTION
## Summary
- Filters `engine.pairs.list` by `isActive` before building the adjacency graph in MaterialSystem
- Prevents stale collision pairs (bodies that have separated but remain in the pair cache) from creating false adjacency
- Updates `MatterEngine` interface to include `isActive?: boolean` on pair type
- Fixes misleading comment that described `pairs.list` as "active collisions"
- Regression test verifies stale pairs are excluded from adjacency

Resolves #91

## Review
Reviewed by the Forge Temperer. Filter is correct (truthy check also excludes undefined). All 12 existing mock pairs updated. Regression test directly validates stale pair exclusion. All tests pass (2084/2084).

🤖 Generated with [Claude Code](https://claude.com/claude-code)