### PR TITLE
Add ESLint boundary enforcement for src/types/

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,32 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // Prevent src/types/ from importing game internals.
+  // The shared types layer must be independent of src/game/ so
+  // dependencies flow game → types, never the reverse.
+  {
+    name: "types-boundary",
+    files: ["src/types/**/*.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@/game/**", "@/game"],
+              message:
+                "src/types/ must not import from the game layer. Move shared types into src/types/ instead.",
+            },
+            {
+              group: ["../game/**", "../../game/**"],
+              message:
+                "src/types/ must not import from the game layer (relative path). Move shared types into src/types/ instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:


### PR DESCRIPTION
## Summary
- Add a scoped `no-restricted-imports` rule in ESLint flat config that prevents `src/types/` from importing `src/game/` modules
- Covers both path-alias (`@/game/**`) and relative (`../game/**`) import patterns with clear error messages
- Enforces the architectural boundary at lint time / CI rather than relying on code review alone

Resolves #126

## Review
Reviewed by the Forge Temperer. All 5 acceptance criteria verified — both violation patterns smoke-tested via `--stdin-filename`. Zero false positives. 2084 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)