### PR TITLE
Fix flaky world-generator determinism test timeout in CI

### DIFF
--- a/src/game/procgen/world-generator.test.ts
+++ b/src/game/procgen/world-generator.test.ts
@@ -17,8 +17,11 @@ function makeConfig(seed = 'test-seed-123'): RunConfig {
 }
 
 /** Exhaust a generator, collecting yields and the return value. */
-function exhaust(config: RunConfig) {
-  const gen = generateWorld(config);
+function exhaust(
+  config: RunConfig,
+  options?: { gridWidth?: number; gridHeight?: number },
+) {
+  const gen = generateWorld(config, options);
   const yields: GenerationProgress[] = [];
 
   let result = gen.next();
@@ -111,9 +114,14 @@ describe('generateWorld', () => {
   });
 
   it('produces the same world for the same seed (determinism)', () => {
+    // Use an 8×8 macro grid (64×64 tiles) so running the pipeline twice
+    // stays well within CI timeouts. The full 32×32 grid is exercised by
+    // the dimension and performance tests — this test only verifies that
+    // identical seeds produce identical output.
     const config = makeConfig('determinism-check');
-    const { worldData: first } = exhaust(config);
-    const { worldData: second } = exhaust(config);
+    const gridOptions = { gridWidth: 8, gridHeight: 8 };
+    const { worldData: first } = exhaust(config, gridOptions);
+    const { worldData: second } = exhaust(config, gridOptions);
 
     // Same tile grid
     expect(first.layout.tiles).toEqual(second.layout.tiles);
@@ -123,7 +131,7 @@ describe('generateWorld', () => {
     expect(first.safehouse.buildingIndex).toBe(second.safehouse.buildingIndex);
     // Same spawn zones
     expect(first.spawnZones).toEqual(second.spawnZones);
-  });
+  }, 15_000);
 
   it('produces different worlds for different seeds', () => {
     const { worldData: a } = exhaust(makeConfig('seed-alpha'));

--- a/src/game/procgen/world-generator.ts
+++ b/src/game/procgen/world-generator.ts
@@ -50,6 +50,7 @@ import { generateSpawnZones } from './spawn-zones';
  */
 export function* generateWorld(
   config: RunConfig,
+  options?: { gridWidth?: number; gridHeight?: number },
 ): Generator<GenerationProgress, WorldData, void> {
   const rng = new RNG(config.seed);
 
@@ -60,7 +61,10 @@ export function* generateWorld(
     progress: 0,
   };
 
-  const { layout, buildingClasses } = generateCityLayout(config.seed);
+  const { layout, buildingClasses } = generateCityLayout(config.seed, {
+    width: options?.gridWidth,
+    height: options?.gridHeight,
+  });
 
   // --- Stage 2: Building interiors (BSP) ---
   yield {


### PR DESCRIPTION
## Summary
- Add optional `gridWidth`/`gridHeight` parameter to `generateWorld()` for test-only grid size override
- Use 8×8 macro grid in determinism test (16× less area, completes well within CI timeout)
- Add 15s per-test timeout as safety net for worst-case CI slowness
- Full 32×32 grid still exercised by dimension and performance tests

Resolves #128

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified:
- Determinism test passes reliably (8×8 grid + 15s timeout)
- All 2084 tests pass, lint clean, TypeScript compiles, build succeeds
- No test skipped — determinism check still runs with full assertions
- Not masking performance — single 32×32 gen is within 2s budget; timeout was 2× gen on slow CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)