### PR TITLE
Fix barricade snap to select nearest object by snap-center distance

### DIFF
--- a/src/game/events/event-bus.ts
+++ b/src/game/events/event-bus.ts
@@ -100,6 +100,8 @@ export interface BarricadeSnapEvent {
   orientation: "horizontal" | "vertical";
   /** True when object is within snap bounds, false when it leaves. */
   snapping: boolean;
+  /** The snapped object's type (e.g. "wooden_plank"). Absent on snap-leave events. */
+  objectType?: string;
 }
 
 /** Emitted when a barricade takes damage (for visual feedback). */

--- a/src/game/systems/barricade-system.test.ts
+++ b/src/game/systems/barricade-system.test.ts
@@ -321,6 +321,95 @@ describe("BarricadeSystem", () => {
       // Verify BARRICADE_PLACE_RANGE is what we expect
       expect(BARRICADE_PLACE_RANGE).toBe(96);
     });
+
+    it("selects the nearest object to snap center when multiple candidates exist", () => {
+      const { ctx, bodyRegistry, eventBus } = createMockContext();
+
+      const playerBody = mockBody();
+      bodyRegistry.register(playerBody);
+      createPlayerEntity(100, 100, playerBody.id);
+
+      const epCenterX = 5 * TILE_SIZE + TILE_SIZE / 2;
+      const epCenterY = 3 * TILE_SIZE + TILE_SIZE / 2;
+
+      // Object A: farther from snap center (offset +20)
+      const bodyA = mockBody(undefined, epCenterX + 20, epCenterY + 20);
+      bodyRegistry.register(bodyA);
+      createObjectEntity(
+        epCenterX + 20, epCenterY + 20, bodyA.id,
+        "wooden_plank", ObjectCategory.Loot, false,
+        { durability: 0.3, flammability: 0.9, conductivity: 0 }, 3,
+      );
+
+      // Object B: closer to snap center (offset +5), inserted later in ECS
+      const bodyB = mockBody(undefined, epCenterX + 5, epCenterY + 5);
+      bodyRegistry.register(bodyB);
+      createObjectEntity(
+        epCenterX + 5, epCenterY + 5, bodyB.id,
+        "metal_sheet", ObjectCategory.Loot, false,
+        { durability: 0.8, flammability: 0, conductivity: 0.6 }, 4,
+      );
+
+      const snapHandler = vi.fn();
+      eventBus.on("barricade-snap", snapHandler);
+
+      ctx.inputState.pointerDown = true;
+      const system = createBarricadeSystem(ctx);
+      system(1 / 60);
+
+      // Should select metal_sheet (closer to snap center), not wooden_plank
+      expect(snapHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snapping: true,
+          objectType: "metal_sheet",
+        }),
+      );
+    });
+
+    it("includes objectType in barricade-snap event for single object", () => {
+      const { ctx, bodyRegistry, eventBus } = createMockContext();
+
+      const playerBody = mockBody();
+      bodyRegistry.register(playerBody);
+      createPlayerEntity(100, 100, playerBody.id);
+
+      const epCenterX = 5 * TILE_SIZE + TILE_SIZE / 2;
+      const epCenterY = 3 * TILE_SIZE + TILE_SIZE / 2;
+      const objBody = mockBody(undefined, epCenterX, epCenterY);
+      bodyRegistry.register(objBody);
+      createObjectEntity(
+        epCenterX, epCenterY, objBody.id,
+        "wooden_plank", ObjectCategory.Loot, false,
+        { durability: 0.3, flammability: 0.9, conductivity: 0 }, 3,
+      );
+
+      const handler = vi.fn();
+      eventBus.on("barricade-snap", handler);
+
+      // Enter snap zone
+      ctx.inputState.pointerDown = true;
+      const system = createBarricadeSystem(ctx);
+      system(1 / 60);
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snapping: true,
+          objectType: "wooden_plank",
+        }),
+      );
+
+      // Move object far away to leave snap zone
+      const entity = interactableEntities.entities[0];
+      entity.position.x = 9999;
+      entity.position.y = 9999;
+      system(1 / 60);
+
+      // snap-leave event should NOT have objectType
+      expect(handler).toHaveBeenCalledTimes(2);
+      const leaveCall = handler.mock.calls[1][0];
+      expect(leaveCall.snapping).toBe(false);
+      expect(leaveCall.objectType).toBeUndefined();
+    });
   });
 
   describe("placement", () => {

--- a/src/game/systems/barricade-system.ts
+++ b/src/game/systems/barricade-system.ts
@@ -141,10 +141,11 @@ export function createBarricadeSystem(ctx: SceneContext): SystemFn {
 
     let currentSnapTarget: WallAnchorPair | null = null;
     let snapObjectEntity: Entity | null = null;
+    let bestSnapDistSq = Infinity;
 
     // Only check for snap when pointer is down (dragging) or just released
     if (ctx.inputState.pointerDown || ctx.inputState.pointerReleased) {
-      // Find the nearest interactable object being dragged near the player
+      // Find the interactable object nearest to its snap center
       for (const entity of interactableEntities) {
         const objX = entity.position.x;
         const objY = entity.position.y;
@@ -155,9 +156,12 @@ export function createBarricadeSystem(ctx: SceneContext): SystemFn {
         // Check if object is near a snap target
         const snapTarget = wallAnchorRegistry.findSnapTarget(objX, objY);
         if (snapTarget) {
-          currentSnapTarget = snapTarget;
-          snapObjectEntity = entity;
-          break; // Use first matching object
+          const d = distSq(objX, objY, snapTarget.centerX, snapTarget.centerY);
+          if (d < bestSnapDistSq) {
+            bestSnapDistSq = d;
+            currentSnapTarget = snapTarget;
+            snapObjectEntity = entity;
+          }
         }
       }
     }
@@ -180,6 +184,7 @@ export function createBarricadeSystem(ctx: SceneContext): SystemFn {
           snapCenter: { x: currentSnapTarget.centerX, y: currentSnapTarget.centerY },
           orientation: currentSnapTarget.orientation,
           snapping: true,
+          objectType: snapObjectEntity?.objectProperties?.objectType,
         });
       }
       activeSnapTarget = currentSnapTarget;


### PR DESCRIPTION
## Summary
- Replace first-match break in barricade snap detection with nearest-candidate tracking loop (object-to-snap-center squared Euclidean distance), matching the established pattern in InteractionSystem and CombatSystem
- Enrich `barricade-snap` event payload with optional `objectType` field so the UI can display what object is about to snap
- Add 2 new tests: multi-candidate nearest selection and single-object objectType regression guard

Resolves #131

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified. Full test suite passes (2086 tests). TypeScript and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)