### PR TITLE
Replace Math.random() with seeded RNG in game systems

### DIFF
--- a/src/game/scenes/game-scene.ts
+++ b/src/game/scenes/game-scene.ts
@@ -38,6 +38,7 @@ import { COMBAT } from "@/game/systems/combat-constants";
 import { createGameEventBus, safeEmit } from "@/game/events/event-bus";
 import { setActiveBus, setActiveSeed, setActiveMinimapInit } from "@/game/PhaserGame";
 import { setBodyInertia } from "@/game/physics/matter-body";
+import { RNG } from "@/lib/rng";
 import { TILE_SIZE, TileType, TILE_PROPERTIES } from "@/game/tiles/tile-types";
 import { TILESET_KEY } from "@/game/tiles/tileset-generator";
 import { getObjectDef } from "@/game/procgen/object-defs";
@@ -143,6 +144,9 @@ export default class GameScene extends Phaser.Scene {
       5,
     );
 
+    // --- Seeded PRNG for deterministic randomness in game systems ---
+    const rng = new RNG(this.worldData.config.seed);
+
     // --- Scene context (shared by all system factories) ---
     const ctx: SceneContext = {
       scene: this,
@@ -151,6 +155,7 @@ export default class GameScene extends Phaser.Scene {
       getAlpha: () => this.gameLoop.alpha,
       clockState: createClockState(),
       eventBus: createGameEventBus(),
+      rng,
       constraintRegistry,
       wallAnchorRegistry,
       materialRegistry,

--- a/src/game/systems/audio-system.ts
+++ b/src/game/systems/audio-system.ts
@@ -44,6 +44,8 @@ interface MusicState {
 
 export function createAudioSystem(ctx: SceneContext): SystemFn {
   const soundManager = ctx.scene.sound;
+  const audioRng = ctx.rng?.derive("audio");
+  const rngFloat = audioRng ? () => audioRng.float() : Math.random;
 
   // --- Volume settings cache ---
   let masterVolume = 1.0;
@@ -435,14 +437,14 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
         if (dist > AUDIO.ZOMBIE_GROAN_RANGE) continue;
 
         // Random chance to groan this tick (low probability per tick)
-        if (Math.random() > 0.02) continue;
+        if (rngFloat() > 0.02) continue;
 
         if (activeGroans >= AUDIO.ZOMBIE_GROAN_MAX_CONCURRENT) continue;
 
         // Play groan with randomized pitch
         const detune =
           AUDIO.ZOMBIE_GROAN_PITCH_MIN +
-          Math.random() * (AUDIO.ZOMBIE_GROAN_PITCH_MAX - AUDIO.ZOMBIE_GROAN_PITCH_MIN);
+          rngFloat() * (AUDIO.ZOMBIE_GROAN_PITCH_MAX - AUDIO.ZOMBIE_GROAN_PITCH_MIN);
 
         activeGroans++;
         playSpatialSfx(SOUND_KEYS.SFX_ZOMBIE_GROAN, z.position.x, z.position.y, { detune });

--- a/src/game/systems/camera-system.ts
+++ b/src/game/systems/camera-system.ts
@@ -27,6 +27,8 @@ export function createCameraSystem(ctx: SceneContext): SystemFn {
     // No camera available — return a no-op system
     return () => {};
   }
+  const cameraRng = ctx.rng?.derive("camera");
+  const rngFloat = cameraRng ? () => cameraRng.float() : Math.random;
 
   // --- Settings ---
   let screenShakeEnabled = true;
@@ -189,8 +191,8 @@ export function createCameraSystem(ctx: SceneContext): SystemFn {
 
     // --- Screen shake ---
     if (shakeIntensity > CAMERA.SHAKE_MIN_THRESHOLD && screenShakeEnabled) {
-      const offsetX = (Math.random() - 0.5) * 2 * shakeIntensity;
-      const offsetY = (Math.random() - 0.5) * 2 * shakeIntensity;
+      const offsetX = (rngFloat() - 0.5) * 2 * shakeIntensity;
+      const offsetY = (rngFloat() - 0.5) * 2 * shakeIntensity;
       cam.scrollX += offsetX;
       cam.scrollY += offsetY;
     }

--- a/src/game/systems/fire-system.test.ts
+++ b/src/game/systems/fire-system.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@/game/ecs/archetypes";
 import { ObjectCategory } from "@/types/procgen";
 import { FIRE } from "./fire-constants";
+import { RNG } from "@/lib/rng";
 
 const DT = 1 / 60;
 
@@ -55,6 +56,7 @@ function createMockContext(
     getAlpha: () => 0,
     clockState: createClockState(),
     eventBus: createGameEventBus(),
+    rng: new RNG("test-seed"),
     materialRegistry,
     constraintRegistry,
     ...overrides,
@@ -156,6 +158,22 @@ function collectEvents<T>(bus: GameEventBus, eventName: string): T[] {
     events.push(e);
   });
   return events;
+}
+
+/**
+ * Create a mock context whose fire-system RNG always returns the given value.
+ * The RNG is controlled via spy on the derived "fire" child's float() method.
+ */
+function createMockContextWithFixedRng(
+  value: number,
+  overrides: Partial<SceneContext> = {},
+): { ctx: SceneContext; fireRng: RNG } {
+  const rng = new RNG("test-seed");
+  const fireRng = rng.derive("fire");
+  vi.spyOn(fireRng, "float").mockReturnValue(value);
+  vi.spyOn(rng, "derive").mockReturnValue(fireRng);
+  const ctx = createMockContext({ rng, ...overrides });
+  return { ctx, fireRng };
 }
 
 beforeEach(() => {
@@ -276,15 +294,12 @@ describe("FireSystem — burn duration", () => {
 
 describe("FireSystem — spread", () => {
   it("spreads fire to nearby flammable objects", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(0);
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
     const target = spawnWoodenPlank(ctx, 140, 100); // 40px away, within 64px radius
     source.material.state = "burning";
-
-    // Force spread to succeed
-    vi.spyOn(Math, "random").mockReturnValue(0);
 
     // Tick enough to trigger spread check
     tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL + 1);
@@ -293,21 +308,20 @@ describe("FireSystem — spread", () => {
   });
 
   it("does not spread to fireproof (metal) objects", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(0);
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
     const metal = spawnMetalSheet(ctx, 140, 100);
     source.material.state = "burning";
 
-    vi.spyOn(Math, "random").mockReturnValue(0);
     tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL + 1);
 
     expect(metal.material.state).toBe("inert");
   });
 
   it("does not spread beyond spread radius", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(0);
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
@@ -315,21 +329,19 @@ describe("FireSystem — spread", () => {
     const target = spawnWoodenPlank(ctx, 100 + FIRE.SPREAD_RADIUS + 10, 100);
     source.material.state = "burning";
 
-    vi.spyOn(Math, "random").mockReturnValue(0);
     tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL + 1);
 
     expect(target.material.state).toBe("inert");
   });
 
   it("emits fire-spread and material-state-changed events", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(0);
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
     spawnWoodenPlank(ctx, 140, 100);
     source.material.state = "burning";
 
-    vi.spyOn(Math, "random").mockReturnValue(0);
     const spreads = collectEvents(ctx.eventBus, "fire-spread");
     const stateChanges = collectEvents(ctx.eventBus, "material-state-changed");
 
@@ -352,14 +364,12 @@ describe("FireSystem — spread", () => {
   });
 
   it("respects the spread check interval cooldown", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(0);
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
     const target = spawnWoodenPlank(ctx, 140, 100);
     source.material.state = "burning";
-
-    vi.spyOn(Math, "random").mockReturnValue(0);
 
     // Tick fewer than the interval — should not spread
     tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL - 1);
@@ -368,7 +378,9 @@ describe("FireSystem — spread", () => {
   });
 
   it("spread probability scales with target flammability", () => {
-    const ctx = createMockContext();
+    const { ctx } = createMockContextWithFixedRng(
+      FIRE.BASE_IGNITION_CHANCE * 0.95 + 0.01,
+    );
     const system = createFireSystem(ctx);
 
     const source = spawnGasCan(ctx, 100, 100);
@@ -376,14 +388,78 @@ describe("FireSystem — spread", () => {
     const sofa = spawnSofa(ctx, 140, 100);
     source.material.state = "burning";
 
-    // Set random to be just above the threshold (should NOT ignite)
-    vi.spyOn(Math, "random").mockReturnValue(
-      FIRE.BASE_IGNITION_CHANCE * 0.95 + 0.01,
-    );
-
     tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL + 1);
 
     expect(sofa.material.state).toBe("inert");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe("FireSystem — determinism", () => {
+  it("fire spread is deterministic given the same seed", () => {
+    function runSpreadScenario(seed: string): string[] {
+      const rng = new RNG(seed);
+      const ctx = createMockContext({ rng });
+      const system = createFireSystem(ctx);
+
+      const source = spawnGasCan(ctx, 100, 100);
+      spawnWoodenPlank(ctx, 140, 100);
+      spawnWoodenPlank(ctx, 100, 140);
+      spawnSofa(ctx, 130, 130);
+      source.material.state = "burning";
+
+      const spreads: string[] = [];
+      ctx.eventBus.on("fire-spread", (e) => {
+        spreads.push(`${e.targetPosition.x},${e.targetPosition.y}`);
+      });
+
+      // Tick enough spread intervals to give fire a chance to spread
+      tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL * 20);
+      return spreads;
+    }
+
+    const run1 = runSpreadScenario("determinism-test");
+    resetWorld();
+    const run2 = runSpreadScenario("determinism-test");
+
+    expect(run1).toEqual(run2);
+  });
+
+  it("different seeds produce different spread sequences", () => {
+    function runSpreadScenario(seed: string): string[] {
+      const rng = new RNG(seed);
+      const ctx = createMockContext({ rng });
+      const system = createFireSystem(ctx);
+
+      const source = spawnGasCan(ctx, 100, 100);
+      spawnWoodenPlank(ctx, 140, 100);
+      spawnWoodenPlank(ctx, 100, 140);
+      spawnSofa(ctx, 130, 130);
+      source.material.state = "burning";
+
+      const spreads: string[] = [];
+      ctx.eventBus.on("fire-spread", (e) => {
+        spreads.push(`${e.targetPosition.x},${e.targetPosition.y}`);
+      });
+
+      tickN(ctx, system, FIRE.SPREAD_CHECK_INTERVAL * 50);
+      return spreads;
+    }
+
+    const runA = runSpreadScenario("seed-alpha");
+    resetWorld();
+    const runB = runSpreadScenario("seed-beta");
+
+    // At least one run should have spreads, and they should differ
+    // (with enough ticks, fire should spread at least once)
+    if (runA.length > 0 && runB.length > 0) {
+      // If both spread, at least their timing/order should differ
+      expect(runA).not.toEqual(runB);
+    }
+    // If one has no spreads, seeds are already producing different outcomes
   });
 });
 

--- a/src/game/systems/fire-system.ts
+++ b/src/game/systems/fire-system.ts
@@ -107,6 +107,10 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
   if (!registry) {
     throw new Error("[FireSystem] ctx.materialRegistry is required");
   }
+  if (!ctx.rng) {
+    throw new Error("[FireSystem] ctx.rng is required");
+  }
+  const fireRng = ctx.rng.derive("fire");
 
   /** Per-entity burn state. */
   const burnState = new Map<Entity, BurnRecord>();
@@ -193,7 +197,7 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
           // Probability check scaled by target flammability
           const chance =
             FIRE.BASE_IGNITION_CHANCE * target.material.flammability;
-          if (Math.random() >= chance) continue;
+          if (fireRng.float() >= chance) continue;
 
           // Ignite the target
           target.material.state = "burning";

--- a/src/game/systems/scene-context.ts
+++ b/src/game/systems/scene-context.ts
@@ -12,6 +12,7 @@ import type { EntityPool } from "@/game/ecs/pool";
 import type { ZombieEntity } from "@/game/ecs/archetypes";
 import type { SensorBodyPool } from "@/game/ecs/sensor-pool";
 import type { PoolManager } from "@/game/ecs/pool-manager";
+import type { RNG } from "@/lib/rng";
 
 /**
  * Snapshot of normalised input state, written by InputSystem each fixed tick
@@ -110,6 +111,8 @@ export interface SceneContext {
   sensorPool?: SensorBodyPool;
   /** Pool manager aggregating all entity pools for diagnostics. */
   poolManager?: PoolManager;
+  /** Seeded PRNG for deterministic randomness across game systems. */
+  rng?: RNG;
 }
 
 /** Create a zeroed-out input state. */


### PR DESCRIPTION
## Summary
- Replaced `Math.random()` with seeded RNG in fire spread (`fire-system.ts`), camera shake (`camera-system.ts`), and zombie audio timing (`audio-system.ts`)
- Added `rng?: RNG` field to `SceneContext`, constructed from run seed in `GameScene.create()`
- Each system derives an isolated child RNG (`"fire"`, `"camera"`, `"audio"`) so adding/removing random calls in one system cannot shift another's sequence
- Fire system throws if RNG is missing (gameplay-critical); camera and audio gracefully fall back to `Math.random` (cosmetic)
- Replaced 6 `vi.spyOn(Math, "random")` calls with proper RNG injection in tests
- Added 2 determinism tests verifying same seed → same fire spread

Resolves #134

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified (including optional scope). 2088 tests pass, lint clean, type check clean. No `Math.random()` remains in production game code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)