### PR TITLE
Add per-system error isolation to prevent permanent crashes

### DIFF
--- a/src/game/events/event-bus.ts
+++ b/src/game/events/event-bus.ts
@@ -381,6 +381,22 @@ export interface DropItemCommandEvent {
   slotIndex?: number;
 }
 
+/** Emitted when a game system throws during execution. */
+export interface SystemErrorEvent {
+  systemIndex: number;
+  systemName: string;
+  error: unknown;
+  errorCount: number;
+  errorBudget: number;
+}
+
+/** Emitted when a game system is disabled after exhausting its error budget. */
+export interface SystemDisabledEvent {
+  systemIndex: number;
+  systemName: string;
+  errorCount: number;
+}
+
 // ---------------------------------------------------------------------------
 // Event map — maps event names to handler signatures
 // ---------------------------------------------------------------------------
@@ -450,6 +466,10 @@ export interface GameEventMap {
 
   // Topology changes (issue #43)
   "topology-changed": [event: TopologyChangedEvent];
+
+  // System health (issue #135)
+  "system-error": [event: SystemErrorEvent];
+  "system-disabled": [event: SystemDisabledEvent];
 
   // UI → Game commands (prefixed with cmd:)
   "cmd:pause": [event: PauseCommandEvent];

--- a/src/game/scenes/game-scene.test.ts
+++ b/src/game/scenes/game-scene.test.ts
@@ -478,15 +478,13 @@ describe("GameScene", () => {
 
     it("calls render systems after gameLoop.tick", () => {
       scene.create();
-      const renderSystems = (
-        scene as unknown as { renderSystems: Array<(dt: number) => void> }
-      ).renderSystems;
-      expect(renderSystems.length).toBeGreaterThan(0);
+      const renderRunner = (
+        scene as unknown as { renderRunner: { run: (dt: number) => void } }
+      ).renderRunner;
+      expect(renderRunner).toBeDefined();
 
-      // Spy on first render system
-      const spy = vi.fn();
-      (scene as unknown as { renderSystems: Array<(dt: number) => void> })
-        .renderSystems[0] = spy;
+      // Spy on render runner
+      const spy = vi.spyOn(renderRunner, "run");
 
       scene.update(0, 16.67);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -580,40 +578,43 @@ describe("GameScene", () => {
   });
 
   describe("update before create", () => {
-    it("catches crash when update() is called before create()", () => {
+    it("logs error when update() is called before create() without crashing", () => {
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
+      // Before create(), commandSystem is uninitialized and isClockPaused()
+      // returns true (null _clockState). The try-catch around commandSystem
+      // during pause catches the error without setting crashed = true.
       scene.update(0, 16.67);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[GameScene] Game loop crashed:",
+        "[GameScene] CommandSystem threw while paused:",
         expect.any(Error),
       );
       consoleSpy.mockRestore();
     });
 
-    it("create() resets the crashed flag so the scene can recover", () => {
+    it("create() recovers from pre-create update calls", () => {
       const consoleSpy = vi
         .spyOn(console, "error")
         .mockImplementation(() => {});
 
-      // Trigger crash: update before create
+      // Pre-create update — error is caught gracefully, no crash
       scene.update(0, 16.67);
       expect(consoleSpy).toHaveBeenCalledTimes(1);
 
       consoleSpy.mockClear();
 
-      // create() should reset crashed flag
+      // create() initializes all systems
       scene.create();
 
-      // Subsequent updates should work (not silently halted)
+      // Subsequent updates should work normally
       scene.update(16.67, 16.67);
       scene.update(33.34, 16.67);
       expect(consoleSpy).not.toHaveBeenCalled();
 
-      // Verify the game loop is ticking (not crashed)
+      // Verify the game loop is ticking
       const gameLoop = (
         scene as unknown as { gameLoop: { tick: (dt: number) => void } }
       ).gameLoop;

--- a/src/game/scenes/game-scene.ts
+++ b/src/game/scenes/game-scene.ts
@@ -1,6 +1,6 @@
 import Phaser from "phaser";
-import { GameLoop, FIXED_DT } from "@/game/systems/game-loop";
-import type { SystemFn } from "@/game/systems/system-runner";
+import { GameLoop, FIXED_DT, MAX_STEPS_PER_FRAME } from "@/game/systems/game-loop";
+import { SystemRunner, type SystemFn } from "@/game/systems/system-runner";
 import { createInputState, createClockState } from "@/game/systems/scene-context";
 import type { SceneContext } from "@/game/systems/scene-context";
 import { BodyRegistry } from "@/game/systems/body-registry";
@@ -53,7 +53,7 @@ import type { WorldData } from "@/types/world";
 export default class GameScene extends Phaser.Scene {
   private gameLoop!: GameLoop;
   private commandSystem!: SystemFn;
-  private renderSystems: SystemFn[] = [];
+  private renderRunner!: SystemRunner;
   private fpsText!: Phaser.GameObjects.Text;
   private showDebug = false;
   private crashed = false;
@@ -249,17 +249,71 @@ export default class GameScene extends Phaser.Scene {
       createAudioSystem(ctx),
     ];
 
-    this.gameLoop = new GameLoop(systems);
+    const systemNames = [
+      "CommandSystem", "InputSystem", "InventorySystem", "InteractionSystem",
+      "BarricadeSystem", "DayNightSystem", "WaveSystem", "MovementSystem",
+      "NoiseSystem", "ZombieAISystem", "CombatSystem", "StatsSystem",
+      "PhysicsSyncSystem", "MaterialSystem", "FireSystem", "ExplosionSystem",
+      "ElectricitySystem", "MinimapDataSystem", "AudioSystem",
+    ];
+
+    const errorBudget = 5;
+
+    this.gameLoop = new GameLoop(systems, FIXED_DT, MAX_STEPS_PER_FRAME, {
+      names: systemNames,
+      errorBudget,
+      onError: (index, name, error, errorCount) => {
+        safeEmit(ctx.eventBus, "system-error", {
+          systemIndex: index,
+          systemName: name,
+          error,
+          errorCount,
+          errorBudget,
+        });
+      },
+      onDisabled: (index, name) => {
+        safeEmit(ctx.eventBus, "system-disabled", {
+          systemIndex: index,
+          systemName: name,
+          errorCount: errorBudget,
+        });
+      },
+    });
 
     // --- Render-phase systems (once per frame, after fixed ticks) ---
     // Camera system runs first so downstream render systems read the final
     // camera position (e.g., LightingSystem reads cam.scrollX/scrollY).
-    this.renderSystems = [
+    const renderSystems: SystemFn[] = [
       createCameraSystem(ctx),
       createRenderSyncSystem(ctx),
       createParticleSystem(ctx),
       createLightingSystem(ctx),
     ];
+
+    const renderNames = [
+      "CameraSystem", "RenderSyncSystem", "ParticleSystem", "LightingSystem",
+    ];
+
+    this.renderRunner = new SystemRunner(renderSystems, {
+      names: renderNames,
+      errorBudget,
+      onError: (index, name, error, errorCount) => {
+        safeEmit(ctx.eventBus, "system-error", {
+          systemIndex: index,
+          systemName: name,
+          error,
+          errorCount,
+          errorBudget,
+        });
+      },
+      onDisabled: (index, name) => {
+        safeEmit(ctx.eventBus, "system-disabled", {
+          systemIndex: index,
+          systemName: name,
+          errorCount: errorBudget,
+        });
+      },
+    });
 
     // --- Handle settings changes from the UI ---
     // Volume settings are handled by the audio system (createAudioSystem).
@@ -298,8 +352,14 @@ export default class GameScene extends Phaser.Scene {
       // When paused, only run the command system (to process resume commands)
       // and skip the full game loop (physics, AI, timers all stop).
       if (this.isClockPaused()) {
-        // Run command system each frame so resume commands are processed
-        this.commandSystem(FIXED_DT);
+        // Run command system each frame so resume commands are processed.
+        // Wrapped in try-catch so a command error cannot freeze the game
+        // and prevent the player from ever resuming.
+        try {
+          this.commandSystem(FIXED_DT);
+        } catch (err) {
+          console.error("[GameScene] CommandSystem threw while paused:", err);
+        }
 
         // Track pause state to reset accumulator on resume
         this.wasPaused = true;
@@ -316,9 +376,8 @@ export default class GameScene extends Phaser.Scene {
       this.gameLoop.tick(delta / 1000);
 
       // Render-phase systems run once per frame after all fixed ticks.
-      for (let i = 0; i < this.renderSystems.length; i++) {
-        this.renderSystems[i](delta / 1000);
-      }
+      // Error-isolated via SystemRunner — a particle crash cannot end the game.
+      this.renderRunner.run(delta / 1000);
     } catch (err) {
       this.crashed = true;
       console.error("[GameScene] Game loop crashed:", err);

--- a/src/game/systems/game-loop.ts
+++ b/src/game/systems/game-loop.ts
@@ -1,4 +1,4 @@
-import { type SystemFn, runSystems } from "./system-runner";
+import { type SystemFn, SystemRunner, type SystemRunnerOptions } from "./system-runner";
 
 /** Fixed physics tick rate: 60 Hz (~16.67 ms per step). */
 export const FIXED_DT = 1 / 60;
@@ -20,6 +20,9 @@ export interface GameLoopStats {
  * Fixed-timestep accumulator that decouples physics (60 Hz) from
  * the browser's variable render rate. Includes a spiral-of-death
  * guard that caps physics steps per frame.
+ *
+ * Uses a {@link SystemRunner} internally for per-system error
+ * isolation — a single throwing system cannot crash the loop.
  */
 export class GameLoop {
   private accumulator = 0;
@@ -32,12 +35,13 @@ export class GameLoop {
 
   private readonly fixedDt: number;
   private readonly maxSteps: number;
-  private readonly systems: readonly SystemFn[];
+  private readonly _runner: SystemRunner;
 
   constructor(
     systems: readonly SystemFn[],
     fixedDt: number = FIXED_DT,
     maxSteps: number = MAX_STEPS_PER_FRAME,
+    runnerOptions?: SystemRunnerOptions,
   ) {
     if (fixedDt <= 0) {
       throw new Error(`[GameLoop] fixedDt must be positive, got ${fixedDt}`);
@@ -47,7 +51,7 @@ export class GameLoop {
         `[GameLoop] maxSteps must be a positive integer, got ${maxSteps}`,
       );
     }
-    this.systems = systems;
+    this._runner = new SystemRunner(systems, runnerOptions);
     this.fixedDt = fixedDt;
     this.maxSteps = maxSteps;
   }
@@ -83,7 +87,7 @@ export class GameLoop {
     // --- Fixed-timestep physics ticks ---
     let steps = 0;
     while (this.accumulator >= this.fixedDt) {
-      runSystems(this.systems, this.fixedDt);
+      this._runner.run(this.fixedDt);
       this.accumulator -= this.fixedDt;
       steps++;
     }
@@ -108,6 +112,11 @@ export class GameLoop {
   /** Smoothed render FPS. */
   get fps(): number {
     return this._fps;
+  }
+
+  /** The internal system runner (for inspection and testing). */
+  get runner(): SystemRunner {
+    return this._runner;
   }
 
   /** Reset the accumulator to zero (call on resume from pause to avoid catch-up ticks). */

--- a/src/game/systems/system-runner.test.ts
+++ b/src/game/systems/system-runner.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { runSystems, type SystemFn } from "@/game/systems/system-runner";
+import {
+  runSystems,
+  SystemRunner,
+  type SystemFn,
+} from "@/game/systems/system-runner";
+
+// ---------------------------------------------------------------------------
+// Original runSystems (unguarded)
+// ---------------------------------------------------------------------------
 
 describe("runSystems", () => {
   it("calls each system with the provided dt", () => {
@@ -82,5 +90,442 @@ describe("runSystems", () => {
     runSystems([sys], 1 / 60);
 
     expect(sys).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SystemRunner (error-isolated)
+// ---------------------------------------------------------------------------
+
+describe("SystemRunner", () => {
+  const DT = 1 / 60;
+
+  describe("constructor validation", () => {
+    it("rejects non-integer errorBudget", () => {
+      expect(() => new SystemRunner([], { errorBudget: 2.5 })).toThrow(
+        /errorBudget must be a positive integer/,
+      );
+    });
+
+    it("rejects errorBudget of zero", () => {
+      expect(() => new SystemRunner([], { errorBudget: 0 })).toThrow(
+        /errorBudget must be a positive integer/,
+      );
+    });
+
+    it("rejects negative errorBudget", () => {
+      expect(() => new SystemRunner([], { errorBudget: -1 })).toThrow(
+        /errorBudget must be a positive integer/,
+      );
+    });
+
+    it("rejects names array with wrong length", () => {
+      expect(
+        () => new SystemRunner([vi.fn(), vi.fn()], { names: ["A"] }),
+      ).toThrow(/names length \(1\) must match systems length \(2\)/);
+    });
+
+    it("accepts matching names array", () => {
+      expect(
+        () => new SystemRunner([vi.fn()], { names: ["Sys"] }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("basic execution", () => {
+    it("calls each system with the provided dt", () => {
+      const a = vi.fn<SystemFn>();
+      const b = vi.fn<SystemFn>();
+      const runner = new SystemRunner([a, b]);
+
+      runner.run(DT);
+
+      expect(a).toHaveBeenCalledWith(DT);
+      expect(b).toHaveBeenCalledWith(DT);
+    });
+
+    it("executes systems in array order", () => {
+      const order: string[] = [];
+      const a: SystemFn = () => order.push("a");
+      const b: SystemFn = () => order.push("b");
+      const c: SystemFn = () => order.push("c");
+      const runner = new SystemRunner([a, b, c]);
+
+      runner.run(DT);
+
+      expect(order).toEqual(["a", "b", "c"]);
+    });
+
+    it("does nothing with an empty array", () => {
+      const runner = new SystemRunner([]);
+      expect(() => runner.run(DT)).not.toThrow();
+    });
+
+    it("makes earlier system mutations visible to later systems", () => {
+      const shared = { value: 0 };
+      const writer: SystemFn = () => { shared.value = 42; };
+      const reader: SystemFn = () => { shared.value *= 2; };
+      const runner = new SystemRunner([writer, reader]);
+
+      runner.run(DT);
+
+      expect(shared.value).toBe(84);
+    });
+  });
+
+  describe("error isolation", () => {
+    it("one system throwing does not prevent others from running", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const before = vi.fn<SystemFn>();
+      const failing: SystemFn = () => { throw new Error("boom"); };
+      const after = vi.fn<SystemFn>();
+      const runner = new SystemRunner([before, failing, after]);
+
+      runner.run(DT);
+
+      expect(before).toHaveBeenCalledTimes(1);
+      expect(after).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("does not throw when a system throws", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const failing: SystemFn = () => { throw new Error("crash"); };
+      const runner = new SystemRunner([failing]);
+
+      expect(() => runner.run(DT)).not.toThrow();
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("logs errors with system identification", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const failing: SystemFn = () => { throw new Error("oops"); };
+      const runner = new SystemRunner([failing], { names: ["TestSystem"] });
+
+      runner.run(DT);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[TestSystem] System error 1/5:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("uses index-based names when no names provided", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const failing: SystemFn = () => { throw new Error("oops"); };
+      const runner = new SystemRunner([failing]);
+
+      runner.run(DT);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[System[0]] System error 1/5:",
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("error budget", () => {
+    it("disables a system after it exceeds the error budget", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      let callCount = 0;
+      const failing: SystemFn = () => {
+        callCount++;
+        throw new Error("repeating");
+      };
+      const runner = new SystemRunner([failing], { errorBudget: 3 });
+
+      // Run 5 times — should only call the system 3 times
+      for (let i = 0; i < 5; i++) runner.run(DT);
+
+      expect(callCount).toBe(3);
+      expect(runner.isDisabled(0)).toBe(true);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("uses default error budget of 5", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      let callCount = 0;
+      const failing: SystemFn = () => {
+        callCount++;
+        throw new Error("oops");
+      };
+      const runner = new SystemRunner([failing]);
+
+      for (let i = 0; i < 10; i++) runner.run(DT);
+
+      expect(callCount).toBe(5);
+      expect(runner.isDisabled(0)).toBe(true);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("error budget of 1 disables on first error", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      let callCount = 0;
+      const failing: SystemFn = () => {
+        callCount++;
+        throw new Error("once");
+      };
+      const runner = new SystemRunner([failing], { errorBudget: 1 });
+
+      runner.run(DT);
+      runner.run(DT);
+      runner.run(DT);
+
+      expect(callCount).toBe(1);
+      expect(runner.isDisabled(0)).toBe(true);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("disabled system does not prevent healthy systems from running", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const healthy = vi.fn<SystemFn>();
+      const failing: SystemFn = () => { throw new Error("bad"); };
+      const runner = new SystemRunner([failing, healthy], { errorBudget: 1 });
+
+      // First run: failing gets called then disabled, healthy still runs
+      runner.run(DT);
+      expect(healthy).toHaveBeenCalledTimes(1);
+
+      // Second run: failing skipped, healthy runs
+      runner.run(DT);
+      expect(healthy).toHaveBeenCalledTimes(2);
+      expect(runner.isDisabled(0)).toBe(true);
+      expect(runner.isDisabled(1)).toBe(false);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("multiple systems can be independently disabled", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const fail1: SystemFn = () => { throw new Error("fail1"); };
+      const healthy = vi.fn<SystemFn>();
+      const fail2: SystemFn = () => { throw new Error("fail2"); };
+      const runner = new SystemRunner([fail1, healthy, fail2], { errorBudget: 1 });
+
+      runner.run(DT);
+
+      expect(runner.isDisabled(0)).toBe(true);
+      expect(runner.isDisabled(1)).toBe(false);
+      expect(runner.isDisabled(2)).toBe(true);
+      expect(runner.disabledCount).toBe(2);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onError on each system error with correct arguments", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const onError = vi.fn();
+      const error = new Error("test error");
+      const failing: SystemFn = () => { throw error; };
+      const runner = new SystemRunner([failing], {
+        names: ["TestSystem"],
+        onError,
+        errorBudget: 10,
+      });
+
+      runner.run(DT);
+
+      expect(onError).toHaveBeenCalledWith(0, "TestSystem", error, 1);
+
+      runner.run(DT);
+
+      expect(onError).toHaveBeenCalledWith(0, "TestSystem", error, 2);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("calls onDisabled once when the error budget is exhausted", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const onDisabled = vi.fn();
+      const failing: SystemFn = () => { throw new Error("fail"); };
+      const runner = new SystemRunner([failing], {
+        names: ["BadSystem"],
+        onDisabled,
+        errorBudget: 2,
+      });
+
+      runner.run(DT); // error 1
+      expect(onDisabled).not.toHaveBeenCalled();
+
+      runner.run(DT); // error 2 — budget exhausted
+      expect(onDisabled).toHaveBeenCalledTimes(1);
+      expect(onDisabled).toHaveBeenCalledWith(0, "BadSystem");
+
+      // Should not be called again
+      runner.run(DT);
+      expect(onDisabled).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("callback resilience", () => {
+    it("a throwing onError callback does not prevent subsequent systems from running", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const failing: SystemFn = () => { throw new Error("sys"); };
+      const after = vi.fn<SystemFn>();
+      const runner = new SystemRunner([failing, after], {
+        onError: () => { throw new Error("callback boom"); },
+      });
+
+      runner.run(DT);
+
+      // The system after the failing one should still have run
+      expect(after).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("a throwing onDisabled callback does not prevent subsequent systems from running", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const failing: SystemFn = () => { throw new Error("sys"); };
+      const after = vi.fn<SystemFn>();
+      const runner = new SystemRunner([failing, after], {
+        errorBudget: 1,
+        onDisabled: () => { throw new Error("disabled boom"); },
+      });
+
+      runner.run(DT);
+
+      expect(after).toHaveBeenCalledTimes(1);
+      expect(runner.isDisabled(0)).toBe(true);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("disabledCount", () => {
+    it("starts at zero", () => {
+      const runner = new SystemRunner([vi.fn(), vi.fn()]);
+      expect(runner.disabledCount).toBe(0);
+    });
+
+    it("reflects current disabled count", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const fail1: SystemFn = () => { throw new Error("a"); };
+      const fail2: SystemFn = () => { throw new Error("b"); };
+      const runner = new SystemRunner([fail1, vi.fn(), fail2], { errorBudget: 1 });
+
+      runner.run(DT);
+
+      expect(runner.disabledCount).toBe(2);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("isDisabled", () => {
+    it("returns false for out-of-range indices", () => {
+      const runner = new SystemRunner([vi.fn()]);
+      expect(runner.isDisabled(-1)).toBe(false);
+      expect(runner.isDisabled(99)).toBe(false);
+    });
+  });
+
+  describe("reset", () => {
+    it("re-enables all disabled systems", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      let callCount = 0;
+      const failing: SystemFn = () => {
+        callCount++;
+        throw new Error("oops");
+      };
+      const runner = new SystemRunner([failing], { errorBudget: 2 });
+
+      runner.run(DT);
+      runner.run(DT); // disabled after 2
+      expect(runner.isDisabled(0)).toBe(true);
+      expect(callCount).toBe(2);
+
+      runner.reset();
+
+      expect(runner.isDisabled(0)).toBe(false);
+      expect(runner.disabledCount).toBe(0);
+
+      // System should run again after reset
+      runner.run(DT);
+      expect(callCount).toBe(3);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("clears error counts so the budget starts fresh", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      let callCount = 0;
+      const failing: SystemFn = () => {
+        callCount++;
+        throw new Error("oops");
+      };
+      const runner = new SystemRunner([failing], { errorBudget: 2 });
+
+      runner.run(DT); // error 1
+      runner.reset();  // clear
+      runner.run(DT); // error 1 again (not 2)
+      runner.run(DT); // error 2 — now disabled
+
+      expect(callCount).toBe(3);
+      expect(runner.isDisabled(0)).toBe(true);
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/src/game/systems/system-runner.ts
+++ b/src/game/systems/system-runner.ts
@@ -9,9 +9,133 @@ export type SystemFn = (dt: number) => void;
  *
  * Systems run synchronously in array order — mutations from system N
  * are visible to system N+1 within the same tick.
+ *
+ * This is the original unguarded runner. Errors propagate immediately
+ * and halt downstream systems. Use {@link SystemRunner} for per-system
+ * error isolation.
  */
 export function runSystems(systems: readonly SystemFn[], dt: number): void {
   for (let i = 0; i < systems.length; i++) {
     systems[i](dt);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-system error-isolated runner
+// ---------------------------------------------------------------------------
+
+/** Default maximum errors before a system is disabled. */
+const DEFAULT_ERROR_BUDGET = 5;
+
+/** Configuration options for {@link SystemRunner}. */
+export interface SystemRunnerOptions {
+  /**
+   * Maximum errors a system may throw before it is permanently disabled
+   * for this runner instance. Default: 5.
+   */
+  errorBudget?: number;
+  /**
+   * Optional human-readable names for each system, used in log messages.
+   * Length must match the systems array. Falls back to index-based
+   * identification when omitted.
+   */
+  names?: readonly string[];
+  /** Called on each system error (after incrementing the count). */
+  onError?: (index: number, name: string, error: unknown, errorCount: number) => void;
+  /** Called once when a system is disabled after exhausting its budget. */
+  onDisabled?: (index: number, name: string) => void;
+}
+
+/**
+ * Error-isolated system executor with per-system error budgets.
+ *
+ * Wraps each system call in its own try-catch so a single failing
+ * system cannot prevent others from running. Systems that exceed
+ * their error budget are permanently disabled for the session.
+ *
+ * Call {@link reset} between runs to re-enable all systems and
+ * clear error counts.
+ */
+export class SystemRunner {
+  private readonly systems: readonly SystemFn[];
+  private readonly errorCounts: number[];
+  private readonly disabledFlags: boolean[];
+  private readonly errorBudget: number;
+  private readonly names: readonly string[];
+  private readonly _onError?: (index: number, name: string, error: unknown, errorCount: number) => void;
+  private readonly _onDisabled?: (index: number, name: string) => void;
+
+  constructor(systems: readonly SystemFn[], options?: SystemRunnerOptions) {
+    const budget = options?.errorBudget ?? DEFAULT_ERROR_BUDGET;
+    if (budget < 1 || !Number.isInteger(budget)) {
+      throw new Error(
+        `[SystemRunner] errorBudget must be a positive integer, got ${budget}`,
+      );
+    }
+    if (options?.names && options.names.length !== systems.length) {
+      throw new Error(
+        `[SystemRunner] names length (${options.names.length}) must match ` +
+        `systems length (${systems.length})`,
+      );
+    }
+    this.systems = systems;
+    this.errorBudget = budget;
+    this.names = options?.names ?? systems.map((_, i) => `System[${i}]`);
+    this._onError = options?.onError;
+    this._onDisabled = options?.onDisabled;
+    this.errorCounts = new Array<number>(systems.length).fill(0);
+    this.disabledFlags = new Array<boolean>(systems.length).fill(false);
+  }
+
+  /**
+   * Run all non-disabled systems with per-system error isolation.
+   *
+   * Systems execute in array order — mutations from system N are
+   * visible to system N+1 within the same tick (same as {@link runSystems}).
+   */
+  run(dt: number): void {
+    for (let i = 0; i < this.systems.length; i++) {
+      if (this.disabledFlags[i]) continue;
+      try {
+        this.systems[i](dt);
+      } catch (err) {
+        const count = ++this.errorCounts[i];
+        const name = this.names[i];
+
+        console.error(
+          `[${name}] System error ${count}/${this.errorBudget}:`,
+          err,
+        );
+        try { this._onError?.(i, name, err, count); } catch { /* swallow — callback must not break isolation */ }
+
+        if (count >= this.errorBudget) {
+          this.disabledFlags[i] = true;
+          console.warn(
+            `[${name}] Disabled after ${count} errors`,
+          );
+          try { this._onDisabled?.(i, name); } catch { /* swallow — callback must not break isolation */ }
+        }
+      }
+    }
+  }
+
+  /** True if the system at this index has been disabled. */
+  isDisabled(index: number): boolean {
+    return this.disabledFlags[index] ?? false;
+  }
+
+  /** Number of currently disabled systems. */
+  get disabledCount(): number {
+    let count = 0;
+    for (let i = 0; i < this.disabledFlags.length; i++) {
+      if (this.disabledFlags[i]) count++;
+    }
+    return count;
+  }
+
+  /** Reset all error counts and re-enable all systems. */
+  reset(): void {
+    this.errorCounts.fill(0);
+    this.disabledFlags.fill(false);
   }
 }


### PR DESCRIPTION
## Summary
- Added `SystemRunner` class with per-system try-catch and configurable error budgets (default: 5 errors before disabling)
- Integrated into `GameLoop` for fixed-tick systems and as a separate runner for render-phase systems in `GameScene`
- Added `system-error` and `system-disabled` event types to the event bus for UI observability
- Wrapped `commandSystem` during pause in try-catch to prevent pause-state lockout
- Constructor validates error budget and system names array length
- Callbacks (`onError`, `onDisabled`) are themselves wrapped in try-catch to guarantee isolation
- Original `runSystems()` function kept for backward compatibility

A single throwing system can no longer permanently freeze the game. Systems that fail repeatedly are disabled after exhausting their error budget, while all other systems continue running normally.

Resolves #135

## Review
Reviewed by the Forge Temperer. All 7 acceptance criteria verified. 2115 tests pass (+27 new), lint clean, type check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)