### PR TITLE
Guard localStorage access against SSR/SSG environments

### DIFF
--- a/src/lib/keybindings-ssr.test.ts
+++ b/src/lib/keybindings-ssr.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment node
+/**
+ * SSR/SSG safety tests for keybindings persistence.
+ *
+ * Runs in a Node environment (no localStorage) to verify that
+ * loadKeybindings and saveKeybindings handle missing localStorage
+ * gracefully without throwing.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  loadKeybindings,
+  saveKeybindings,
+  DEFAULT_KEYBINDINGS,
+} from "./keybindings";
+
+describe("keybindings — SSR/SSG safety", () => {
+  it("loadKeybindings returns defaults when localStorage is unavailable", () => {
+    const result = loadKeybindings();
+    expect(result).toEqual(DEFAULT_KEYBINDINGS);
+  });
+
+  it("saveKeybindings is a silent no-op when localStorage is unavailable", () => {
+    expect(() => saveKeybindings(DEFAULT_KEYBINDINGS)).not.toThrow();
+  });
+});

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -88,6 +88,7 @@ const STORAGE_KEY = "deadbolt-keybindings";
 
 /** Load keybindings from localStorage, merging with defaults. */
 export function loadKeybindings(): KeyBindingMap {
+  if (typeof localStorage === "undefined") return { ...DEFAULT_KEYBINDINGS };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULT_KEYBINDINGS };
@@ -115,6 +116,7 @@ export function loadKeybindings(): KeyBindingMap {
 
 /** Persist keybindings to localStorage. */
 export function saveKeybindings(bindings: KeyBindingMap): void {
+  if (typeof localStorage === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(bindings));
   } catch {

--- a/src/lib/settings-ssr.test.ts
+++ b/src/lib/settings-ssr.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+/**
+ * SSR/SSG safety tests for settings persistence.
+ *
+ * Runs in a Node environment (no localStorage) to verify that
+ * loadSettings and saveSettings handle missing localStorage gracefully
+ * without throwing or logging warnings.
+ */
+import { describe, it, expect } from "vitest";
+import { loadSettings, saveSettings, DEFAULT_SETTINGS } from "./settings";
+
+describe("settings — SSR/SSG safety", () => {
+  it("loadSettings returns defaults when localStorage is unavailable", () => {
+    const result = loadSettings();
+    expect(result).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("saveSettings is a silent no-op when localStorage is unavailable", () => {
+    expect(() => saveSettings(DEFAULT_SETTINGS)).not.toThrow();
+  });
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -61,6 +61,7 @@ const STORAGE_KEY = "deadbolt-settings";
  * missing or corrupt fields. Returns defaults if nothing is stored.
  */
 export function loadSettings(): GameSettings {
+  if (typeof localStorage === "undefined") return { ...DEFAULT_SETTINGS };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULT_SETTINGS };
@@ -103,6 +104,7 @@ export function loadSettings(): GameSettings {
 
 /** Persist settings to localStorage. */
 export function saveSettings(settings: GameSettings): void {
+  if (typeof localStorage === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
   } catch (err) {


### PR DESCRIPTION
## Summary
- Added `typeof localStorage === "undefined"` early-return guards to `loadSettings()`, `saveSettings()`, `loadKeybindings()`, and `saveKeybindings()`
- Load functions return defaults; save functions are no-ops when localStorage is unavailable (SSR/SSG)
- Eliminates the `[Settings] Failed to load settings, using defaults: ReferenceError: localStorage is not defined` build warning
- Added 2 new SSR test files (`settings-ssr.test.ts`, `keybindings-ssr.test.ts`) using `// @vitest-environment node` to verify behavior without localStorage

Resolves #136

## Review
Reviewed by the Forge Temperer. All 7 acceptance criteria verified. Build produces zero localStorage warnings. 2119 tests pass (108 files), lint clean, type check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)