### PR TITLE
Add security headers and CSP to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,31 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; media-src 'self'; worker-src 'self' blob:; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=()"
+        }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary
- Added catch-all security headers block to `vercel.json` covering all routes via `/(.*)`
- **Content-Security-Policy**: Restrictive baseline — `default-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, with targeted relaxations for Next.js (`'unsafe-inline'` for script/style) and Phaser (`data:`, `blob:` for img/worker)
- **X-Frame-Options**: `DENY` — prevents clickjacking
- **X-Content-Type-Options**: `nosniff` — prevents MIME sniffing
- **Referrer-Policy**: `strict-origin-when-cross-origin`
- **Permissions-Policy**: Disables camera, microphone, geolocation, and payment APIs
- Bonus hardening: `base-uri 'self'` and `form-action 'self'` beyond original requirements
- Existing `/assets/` cache headers preserved

Resolves #137

## Review
Reviewed by the Forge Temperer. All pre-deployment acceptance criteria verified (3/3). Post-deployment criteria (4-6) deferred — no Vercel project connected yet. Build succeeds with all 5 static pages generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)