### PR TITLE
Use crypto.randomUUID() for run IDs, monotonic counter for notifications

### DIFF
--- a/src/lib/bridge.ts
+++ b/src/lib/bridge.ts
@@ -22,6 +22,7 @@ import { usePlayerStore } from "@/stores/usePlayerStore";
 import { useUIStore } from "@/stores/useUIStore";
 import { useMinimapStore } from "@/stores/useMinimapStore";
 import { useSettingsStore } from "@/stores/useSettingsStore";
+import { generateEphemeralId } from "@/lib/ids";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -111,7 +112,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
 
   onBus("player-hit", (e) => {
     useUIStore.getState().addNotification({
-      id: `hit-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("hit"),
       message: `Took ${e.damage} damage!`,
       type: "danger",
       timestamp: Date.now(),
@@ -135,7 +136,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
 
   onBus("inventory-full", (e) => {
     useUIStore.getState().addNotification({
-      id: `inv-full-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("inv-full"),
       message: `Inventory full — cannot pick up ${e.displayName}`,
       type: "warning",
       timestamp: Date.now(),
@@ -144,7 +145,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
 
   onBus("item-picked-up", (e) => {
     useUIStore.getState().addNotification({
-      id: `pickup-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("pickup"),
       message: `Picked up ${e.quantity}x ${e.itemType}`,
       type: "info",
       timestamp: Date.now(),
@@ -154,7 +155,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
   onBus("barricade-placed", () => {
     useGameStore.getState().incrementBarricadesBuilt();
     useUIStore.getState().addNotification({
-      id: `barricade-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("barricade"),
       message: "Barricade placed",
       type: "success",
       timestamp: Date.now(),
@@ -163,7 +164,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
 
   onBus("barricade-broken", () => {
     useUIStore.getState().addNotification({
-      id: `barricade-broken-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("barricade-broken"),
       message: "A barricade was destroyed!",
       type: "danger",
       timestamp: Date.now(),
@@ -189,7 +190,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
     // Only forward significant noise to the UI (skip footsteps, drag)
     if (e.intensity >= NOISE.UI_INTENSITY_THRESHOLD) {
       useUIStore.getState().addNoiseIndicator({
-        id: `noise-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+        id: generateEphemeralId("noise"),
         position: e.position,
         intensity: e.intensity,
         source: e.source,
@@ -200,7 +201,7 @@ export function connectBridge(bus: GameEventBus): BridgeConnection {
 
   onBus("object-examined", (e) => {
     useUIStore.getState().addNotification({
-      id: `examine-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateEphemeralId("examine"),
       message: `${e.displayName}: Durability ${Math.round(e.properties.durability * 100)}%, ${e.properties.immovable ? "Immovable" : "Movable"}`,
       type: "info",
       timestamp: Date.now(),

--- a/src/lib/ids.test.ts
+++ b/src/lib/ids.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  generateRunId,
+  generateEphemeralId,
+  _resetEphemeralCounter,
+} from "./ids";
+
+const UUID_V4_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+beforeEach(() => {
+  _resetEphemeralCounter();
+});
+
+describe("generateRunId", () => {
+  it("returns a string starting with 'run-'", () => {
+    const id = generateRunId();
+    expect(id.startsWith("run-")).toBe(true);
+  });
+
+  it("contains a valid UUID v4 after the prefix", () => {
+    const id = generateRunId();
+    const uuidPart = id.slice(4); // remove "run-"
+    expect(uuidPart).toMatch(UUID_V4_REGEX);
+  });
+
+  it("produces unique IDs across 1000 calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      ids.add(generateRunId());
+    }
+    expect(ids.size).toBe(1000);
+  });
+});
+
+describe("generateEphemeralId", () => {
+  it("returns a string starting with the given prefix", () => {
+    expect(generateEphemeralId("hit")).toMatch(/^hit-/);
+    expect(generateEphemeralId("pickup")).toMatch(/^pickup-/);
+  });
+
+  it("produces monotonically increasing counters", () => {
+    const a = generateEphemeralId("test");
+    const b = generateEphemeralId("test");
+    const c = generateEphemeralId("test");
+
+    expect(a).toBe("test-1");
+    expect(b).toBe("test-2");
+    expect(c).toBe("test-3");
+  });
+
+  it("uses a shared counter across different prefixes", () => {
+    const a = generateEphemeralId("hit");
+    const b = generateEphemeralId("pickup");
+    const c = generateEphemeralId("noise");
+
+    expect(a).toBe("hit-1");
+    expect(b).toBe("pickup-2");
+    expect(c).toBe("noise-3");
+  });
+
+  it("never produces duplicate IDs", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateEphemeralId("test"));
+    }
+    expect(ids.size).toBe(100);
+  });
+});
+
+describe("_resetEphemeralCounter", () => {
+  it("resets the counter so IDs start from 1 again", () => {
+    generateEphemeralId("a");
+    generateEphemeralId("a");
+    expect(generateEphemeralId("a")).toBe("a-3");
+
+    _resetEphemeralCounter();
+
+    expect(generateEphemeralId("a")).toBe("a-1");
+  });
+});

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,0 +1,38 @@
+/**
+ * Centralized ID generation utilities.
+ *
+ * Run IDs use crypto.randomUUID() for collision resistance (122-bit entropy).
+ * Ephemeral IDs use a monotonic counter for zero-cost uniqueness within a session.
+ *
+ * @module
+ */
+
+/**
+ * Generate a unique run ID for IndexedDB persistence.
+ * Uses crypto.randomUUID() — 122 bits of entropy, effectively zero collision risk.
+ */
+export function generateRunId(): string {
+  return `run-${crypto.randomUUID()}`;
+}
+
+/** Module-scoped monotonic counter for ephemeral IDs. */
+let ephemeralCounter = 0;
+
+/**
+ * Generate a unique ephemeral ID for notifications, noise indicators, etc.
+ * Uses a monotonic counter — guaranteed unique within a single page session.
+ * Cheaper than crypto and sufficient for short-lived React keys.
+ *
+ * @param prefix - A descriptive prefix (e.g. "hit", "pickup", "noise").
+ */
+export function generateEphemeralId(prefix: string): string {
+  return `${prefix}-${++ephemeralCounter}`;
+}
+
+/**
+ * Reset the ephemeral counter. Only for testing.
+ * @internal
+ */
+export function _resetEphemeralCounter(): void {
+  ephemeralCounter = 0;
+}

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -10,6 +10,7 @@ import {
   _resetDBConnection,
 } from "./persistence";
 import type { CompletedRun } from "@/types/persistence";
+import { generateRunId } from "./ids";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,7 +18,7 @@ import type { CompletedRun } from "@/types/persistence";
 
 function makeRun(overrides: Partial<CompletedRun> = {}): CompletedRun {
   return {
-    id: `run-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    id: generateRunId(),
     seed: "test-seed",
     completedAt: Date.now(),
     elapsedTotal: 300,
@@ -89,6 +90,21 @@ describe("saveRun + loadRunHistory", () => {
     expect(ids).not.toContain("run-4");
     // The newest should still be there
     expect(ids).toContain("run-24");
+  });
+
+  it("rapid sequential saves do not overwrite each other", async () => {
+    const runs = Array.from({ length: 5 }, (_, i) =>
+      makeRun({ totalKills: i * 10, score: i * 100 }),
+    );
+
+    await Promise.all(runs.map(saveRun));
+
+    const history = await loadRunHistory();
+    expect(history).toHaveLength(5);
+
+    // Verify each run's ID is unique
+    const ids = new Set(history.map((r) => r.id));
+    expect(ids.size).toBe(5);
   });
 });
 

--- a/src/stores/usePersistenceStore.ts
+++ b/src/stores/usePersistenceStore.ts
@@ -12,6 +12,7 @@
 import { create } from "zustand";
 import type { CompletedRun, LifetimeStats } from "@/types/persistence";
 import { EMPTY_LIFETIME_STATS, computeRunScore } from "@/types/persistence";
+import { generateRunId } from "@/lib/ids";
 import {
   saveRun,
   loadRunHistory,
@@ -112,7 +113,7 @@ export const usePersistenceStore = create<
 
   recordRun: async (stats) => {
     const run: CompletedRun = {
-      id: `run-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      id: generateRunId(),
       seed: stats.seed,
       completedAt: Date.now(),
       elapsedTotal: stats.elapsedTotal,


### PR DESCRIPTION
## Summary
- Created centralized `src/lib/ids.ts` module with two ID generation strategies:
  - `generateRunId()` — `crypto.randomUUID()` (122-bit entropy) for IndexedDB primary keys
  - `generateEphemeralId(prefix)` — monotonic counter for short-lived React keys (notifications, noise indicators)
- Replaced `Math.random().toString(36).slice(2, 6)` in `usePersistenceStore.ts` (run IDs) and all 7 locations in `bridge.ts` (notification/noise IDs)
- Added 8 unit tests for the new `ids.ts` module and a rapid-sequential-saves collision test for persistence
- Eliminates silent IndexedDB primary key collision risk (was ~20 bits of entropy, now 122 bits)

Resolves #138

## Review
Reviewed by the Forge Temperer. All 5 acceptance criteria verified. 2128 tests pass (109 files), lint clean, type check clean. Zero `Math.random()` remaining in target files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)