### PR TITLE
Replace bare catch blocks in audio, explosion, camera, and material systems

### DIFF
--- a/src/game/scenes/game-scene.test.ts
+++ b/src/game/scenes/game-scene.test.ts
@@ -612,7 +612,12 @@ describe("GameScene", () => {
       // Subsequent updates should work normally
       scene.update(16.67, 16.67);
       scene.update(33.34, 16.67);
-      expect(consoleSpy).not.toHaveBeenCalled();
+      // MaterialSystem logs console.error when Matter.js engine is missing
+      // (expected in mocks). Filter it out — this test verifies no crash errors.
+      const unexpectedErrors = consoleSpy.mock.calls.filter(
+        (args) => !String(args[0]).includes("[MaterialSystem]"),
+      );
+      expect(unexpectedErrors).toHaveLength(0);
 
       // Verify the game loop is ticking
       const gameLoop = (

--- a/src/game/systems/audio-system.ts
+++ b/src/game/systems/audio-system.ts
@@ -52,6 +52,9 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
   let sfxVolume = 0.8;
   let musicVolume = 0.6;
 
+  // --- Warn-once tracking for sound playback failures ---
+  const warnedSoundKeys = new Set<string>();
+
   // --- Mute state ---
   let muted = false;
   let prevMuteKeyDown = false;
@@ -126,8 +129,11 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
     if (vol <= 0) return;
     try {
       soundManager.play(key, { volume: vol });
-    } catch {
-      // Sound may not be loaded — silently skip
+    } catch (err) {
+      if (!warnedSoundKeys.has(key)) {
+        warnedSoundKeys.add(key);
+        console.warn(`[AudioSystem] Failed to play UI SFX "${key}":`, err);
+      }
     }
   }
 
@@ -160,8 +166,11 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
         pan,
         ...extraConfig,
       });
-    } catch {
-      // Sound may not be loaded — silently skip
+    } catch (err) {
+      if (!warnedSoundKeys.has(key)) {
+        warnedSoundKeys.add(key);
+        console.warn(`[AudioSystem] Failed to play spatial SFX "${key}":`, err);
+      }
     }
   }
 
@@ -180,7 +189,9 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
       try {
         (music.incomingSound as Phaser.Sound.WebAudioSound).stop();
         music.incomingSound.destroy();
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.warn("[AudioSystem] Failed to stop outgoing music during crossfade:", err);
+      }
     }
 
     // Begin crossfade — store outgoing volume for smooth fade-out
@@ -202,7 +213,8 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
           0.001 * musicVol,
         );
       }
-    } catch {
+    } catch (err) {
+      console.warn(`[AudioSystem] Failed to start music track "${key}":`, err);
       music.phase = "idle";
     }
   }
@@ -221,7 +233,9 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
         try {
           (music.currentSound as Phaser.Sound.WebAudioSound).stop();
           music.currentSound.destroy();
-        } catch { /* ignore */ }
+        } catch (err) {
+          console.warn("[AudioSystem] Failed to stop outgoing track after crossfade:", err);
+        }
       }
 
       music.currentKey = music.incomingKey;
@@ -375,12 +389,12 @@ export function createAudioSystem(ctx: SceneContext): SystemFn {
     // --- Pause sync ---
     const isPaused = ctx.clockState.paused;
     if (isPaused && !wasPausedLastTick) {
-      try { soundManager.pauseAll(); } catch { /* ignore */ }
+      try { soundManager.pauseAll(); } catch (err) { console.warn("[AudioSystem] pauseAll failed:", err); }
       wasPausedLastTick = true;
       return;
     }
     if (!isPaused && wasPausedLastTick) {
-      try { soundManager.resumeAll(); } catch { /* ignore */ }
+      try { soundManager.resumeAll(); } catch (err) { console.warn("[AudioSystem] resumeAll failed:", err); }
       wasPausedLastTick = false;
     }
     if (isPaused) return;

--- a/src/game/systems/camera-system.ts
+++ b/src/game/systems/camera-system.ts
@@ -24,7 +24,7 @@ import { playerEntities } from "@/game/ecs/queries";
 export function createCameraSystem(ctx: SceneContext): SystemFn {
   const cam = ctx.scene.cameras.main;
   if (!cam) {
-    // No camera available — return a no-op system
+    console.error("[CameraSystem] Main camera not found — camera system disabled");
     return () => {};
   }
   const cameraRng = ctx.rng?.derive("camera");
@@ -58,8 +58,8 @@ export function createCameraSystem(ctx: SceneContext): SystemFn {
     try {
       plusKey = kb.addKey("PLUS");
       minusKey = kb.addKey("MINUS");
-    } catch {
-      // Key capture may fail in test environments
+    } catch (err) {
+      console.warn("[CameraSystem] Failed to capture zoom keys:", err);
     }
   }
 

--- a/src/game/systems/explosion-system.ts
+++ b/src/game/systems/explosion-system.ts
@@ -76,12 +76,18 @@ function pixelToTile(px: number): number {
   return Math.floor(px / TILE_SIZE);
 }
 
-/** Run a callback, silently swallowing errors (Phaser APIs may not exist in tests). */
+/** One-time flag to avoid spamming the console if a visual effect fails. */
+let warnedVisualFailure = false;
+
+/** Run a visual callback, logging the first failure instead of silently swallowing. */
 function tryVisual(fn: () => void): void {
   try {
     fn();
-  } catch {
-    // Phaser scene/camera APIs may not be available in test environments
+  } catch (err) {
+    if (!warnedVisualFailure) {
+      warnedVisualFailure = true;
+      console.warn("[ExplosionSystem] Visual effect failed:", err);
+    }
   }
 }
 

--- a/src/game/systems/material-system.test.ts
+++ b/src/game/systems/material-system.test.ts
@@ -931,7 +931,7 @@ describe("MaterialSystem missing engine", () => {
   }
 
   it("runs without crashing when Matter.js engine is missing", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = createNoEngineContext();
     const system = createMaterialSystem(ctx);
     spawnGasCan(ctx, 100, 100);
@@ -939,11 +939,11 @@ describe("MaterialSystem missing engine", () => {
     expect(() => system(DT)).not.toThrow();
     expect(() => system(DT)).not.toThrow();
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
-  it("warns exactly once when engine is missing", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("errors exactly once when engine is missing", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = createNoEngineContext();
     const system = createMaterialSystem(ctx);
     spawnGasCan(ctx, 100, 100);
@@ -952,17 +952,17 @@ describe("MaterialSystem missing engine", () => {
     system(DT);
     system(DT);
 
-    const engineWarnings = warnSpy.mock.calls.filter((args) =>
+    const engineErrors = errorSpy.mock.calls.filter((args) =>
       String(args[0]).includes("[MaterialSystem]"),
     );
-    expect(engineWarnings).toHaveLength(1);
-    expect(engineWarnings[0][0]).toContain("engine not found");
+    expect(engineErrors).toHaveLength(1);
+    expect(engineErrors[0][0]).toContain("engine not found");
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it("adjacency is empty (not stale) when engine is missing", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = createNoEngineContext();
     const system = createMaterialSystem(ctx);
 
@@ -976,7 +976,7 @@ describe("MaterialSystem missing engine", () => {
     expect(ctx.materialRegistry!.getAdjacentEntities(wire.physicsBody.bodyId)).toHaveLength(0);
     expect(ctx.materialRegistry!.getAdjacentEntities(metal.physicsBody.bodyId)).toHaveLength(0);
 
-    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });
 

--- a/src/game/systems/material-system.ts
+++ b/src/game/systems/material-system.ts
@@ -299,7 +299,7 @@ export function createMaterialSystem(ctx: SceneContext): SystemFn {
     const engine = matterWorld.engine as MatterEngine | undefined;
 
     if (!engine && !warnedMissingEngine) {
-      console.warn(
+      console.error(
         "[MaterialSystem] Matter.js engine not found on ctx.scene.matter.world. Adjacency detection disabled.",
       );
       warnedMissingEngine = true;


### PR DESCRIPTION
## Summary
- Replace all bare `catch {}` blocks in four game systems with logged error handling
- Audio system uses per-sound-key deduplication via `Set<string>` for SFX errors
- Explosion system's `tryVisual()` logs first failure via module-scoped warn-once flag
- Material system upgraded from `console.warn` to `console.error` for missing engine
- Camera system logs `console.error` for missing camera, `console.warn` for keyboard capture failure
- Tests updated: material-system tests spy on `console.error`, game-scene recovery test filters expected MaterialSystem diagnostics

Resolves #139

## Review
Reviewed by the Forge Temperer. All 7 acceptance criteria verified. 2128/2128 tests pass. Types clean. Lint clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)