### PR TITLE
Surface persistence read/save failures to UI

### DIFF
--- a/src/components/death-screen.test.tsx
+++ b/src/components/death-screen.test.tsx
@@ -24,6 +24,8 @@ beforeEach(() => {
   usePersistenceStore.setState({
     loaded: true,
     available: true,
+    loadError: null,
+    saveError: null,
     runHistory: [],
     leaderboard: [],
     lifetimeStats: {
@@ -252,6 +254,41 @@ describe("DeathScreen", () => {
       render(<DeathScreen />);
       expect(screen.getByTestId("copy-seed-btn")).toBeTruthy();
       expect(screen.getByText("Copy")).toBeTruthy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Button handlers
+  // -------------------------------------------------------------------------
+
+  // -------------------------------------------------------------------------
+  // Save error display
+  // -------------------------------------------------------------------------
+
+  describe("save error display", () => {
+    it("shows save error banner when saveError is set", () => {
+      useUIStore.getState().openMenu("death");
+      usePersistenceStore.setState({ saveError: "This run may not have been saved." });
+      render(<DeathScreen />);
+      expect(screen.getByTestId("persistence-save-error")).toBeTruthy();
+      expect(screen.getByText(/may not have been saved/)).toBeTruthy();
+    });
+
+    it("does not show save error banner when saveError is null", () => {
+      useUIStore.getState().openMenu("death");
+      usePersistenceStore.setState({ saveError: null });
+      render(<DeathScreen />);
+      expect(screen.queryByTestId("persistence-save-error")).toBeNull();
+    });
+
+    it("still shows all run stats when save fails", () => {
+      useUIStore.getState().openMenu("death");
+      useGameStore.setState({ totalKills: 42, dayNumber: 3 });
+      usePersistenceStore.setState({ saveError: "This run may not have been saved." });
+      render(<DeathScreen />);
+      expect(screen.getByText("42")).toBeTruthy();
+      expect(screen.getByText("3")).toBeTruthy();
+      expect(screen.getByText("YOU DIED")).toBeTruthy();
     });
   });
 

--- a/src/components/death-screen.tsx
+++ b/src/components/death-screen.tsx
@@ -54,6 +54,7 @@ const VARIANT_LABELS: Record<string, string> = {
 export function DeathScreen() {
   const router = useRouter();
   const activeMenu = useUIStore((s) => s.activeMenu);
+  const saveError = usePersistenceStore((s) => s.saveError);
 
   // --- Run stats from game store ---
   const elapsedTotal = useGameStore((s) => s.elapsedTotal);
@@ -272,6 +273,16 @@ export function DeathScreen() {
                   {copied ? "Copied!" : "Copy"}
                 </Button>
               </div>
+            </div>
+          )}
+          {/* Save error warning */}
+          {saveError && (
+            <div
+              className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-center text-xs text-amber-400"
+              data-testid="persistence-save-error"
+              role="alert"
+            >
+              {saveError}
             </div>
           )}
         </CardContent>

--- a/src/components/landing-stats.test.tsx
+++ b/src/components/landing-stats.test.tsx
@@ -10,6 +10,8 @@ beforeEach(() => {
   usePersistenceStore.setState({
     loaded: false,
     available: false,
+    loadError: null,
+    saveError: null,
     runHistory: [],
     leaderboard: [],
     lifetimeStats: { ...EMPTY_LIFETIME_STATS, killsByType: {} },
@@ -125,6 +127,35 @@ describe("LandingStats", () => {
       const input = screen.getByTestId("seed-input") as HTMLInputElement;
       fireEvent.change(input, { target: { value: "my-seed" } });
       expect(input.value).toBe("my-seed");
+    });
+  });
+
+  describe("persistence load error", () => {
+    it("shows error banner when loadError is set", () => {
+      usePersistenceStore.setState({
+        loaded: true,
+        available: false,
+        loadError: "Failed to load saved data. Your run history may be unavailable.",
+      });
+      render(<LandingStats />);
+      expect(screen.getByTestId("persistence-load-error")).toBeTruthy();
+      expect(screen.getByText(/Failed to load/)).toBeTruthy();
+    });
+
+    it("still shows the play button when load fails", () => {
+      usePersistenceStore.setState({
+        loaded: true,
+        available: false,
+        loadError: "Failed to load saved data.",
+      });
+      render(<LandingStats />);
+      expect(screen.getByText("Play")).toBeTruthy();
+    });
+
+    it("does not show error banner when load succeeds", () => {
+      usePersistenceStore.setState({ loaded: true, available: true, loadError: null });
+      render(<LandingStats />);
+      expect(screen.queryByTestId("persistence-load-error")).toBeNull();
     });
   });
 

--- a/src/components/landing-stats.tsx
+++ b/src/components/landing-stats.tsx
@@ -33,6 +33,7 @@ function formatTotalTime(seconds: number): string {
  */
 export function LandingStats() {
   const loaded = usePersistenceStore((s) => s.loaded);
+  const loadError = usePersistenceStore((s) => s.loadError);
   const lifetimeStats = usePersistenceStore((s) => s.lifetimeStats);
   const leaderboard = usePersistenceStore((s) => s.leaderboard);
 
@@ -96,6 +97,17 @@ export function LandingStats() {
       >
         Best played on desktop with mouse and keyboard
       </div>
+
+      {/* --- Persistence load error --- */}
+      {loaded && loadError && (
+        <div
+          className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-center text-xs text-amber-400"
+          data-testid="persistence-load-error"
+          role="alert"
+        >
+          {loadError}
+        </div>
+      )}
 
       {/* --- Lifetime stats (only when data exists) --- */}
       {hasStats && (

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "fake-indexeddb/auto";
 import {
   saveRun,
@@ -201,5 +201,52 @@ describe("computeLifetimeFromRuns (pure)", () => {
   it("returns empty stats for empty array", () => {
     const stats = computeLifetimeFromRuns([]);
     expect(stats.totalRuns).toBe(0);
+  });
+});
+
+describe("error propagation", () => {
+  let originalOpen: typeof indexedDB.open;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetDBConnection();
+    originalOpen = indexedDB.open.bind(indexedDB);
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    Object.defineProperty(indexedDB, "open", { value: originalOpen, writable: true });
+    errorSpy.mockRestore();
+  });
+
+  function breakDB() {
+    Object.defineProperty(indexedDB, "open", {
+      value: () => { throw new Error("DB blocked"); },
+      writable: true,
+    });
+  }
+
+  it("loadRunHistory rejects when IndexedDB fails", async () => {
+    breakDB();
+    await expect(loadRunHistory()).rejects.toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("getLeaderboard rejects when IndexedDB fails", async () => {
+    breakDB();
+    await expect(getLeaderboard()).rejects.toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("getLifetimeStats rejects when IndexedDB fails", async () => {
+    breakDB();
+    await expect(getLifetimeStats()).rejects.toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("saveRun rejects when IndexedDB fails", async () => {
+    breakDB();
+    await expect(saveRun(makeRun())).rejects.toThrow();
+    expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -118,7 +118,8 @@ export async function saveRun(run: CompletedRun): Promise<void> {
     // Prune old runs beyond MAX_HISTORY (separate transaction)
     await pruneOldRuns(db);
   } catch (err) {
-    console.warn("[Persistence] Failed to save run:", err);
+    console.error("[Persistence] Failed to save run:", err);
+    throw err;
   }
 }
 
@@ -173,7 +174,8 @@ export async function clearAllRuns(): Promise<void> {
     await idbRequest(store.clear());
     await idbTransaction(tx);
   } catch (err) {
-    console.warn("[Persistence] Failed to clear runs:", err);
+    console.error("[Persistence] Failed to clear runs:", err);
+    throw err;
   }
 }
 
@@ -207,8 +209,8 @@ export async function loadRunHistory(): Promise<CompletedRun[]> {
       cursor.onerror = () => reject(cursor.error);
     });
   } catch (err) {
-    console.warn("[Persistence] Failed to load run history:", err);
-    return [];
+    console.error("[Persistence] Failed to load run history:", err);
+    throw err;
   }
 }
 
@@ -238,8 +240,8 @@ export async function getLeaderboard(): Promise<CompletedRun[]> {
       cursor.onerror = () => reject(cursor.error);
     });
   } catch (err) {
-    console.warn("[Persistence] Failed to load leaderboard:", err);
-    return [];
+    console.error("[Persistence] Failed to load leaderboard:", err);
+    throw err;
   }
 }
 
@@ -255,8 +257,8 @@ export async function getLifetimeStats(): Promise<LifetimeStats> {
 
     return computeLifetimeFromRuns(allRuns);
   } catch (err) {
-    console.warn("[Persistence] Failed to compute lifetime stats:", err);
-    return { ...EMPTY_LIFETIME_STATS };
+    console.error("[Persistence] Failed to compute lifetime stats:", err);
+    throw err;
   }
 }
 

--- a/src/stores/usePersistenceStore.test.ts
+++ b/src/stores/usePersistenceStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "fake-indexeddb/auto";
 import { usePersistenceStore } from "./usePersistenceStore";
 import { _resetDBConnection, clearAllRuns } from "@/lib/persistence";
@@ -14,6 +14,8 @@ beforeEach(async () => {
   usePersistenceStore.setState({
     loaded: false,
     available: false,
+    loadError: null,
+    saveError: null,
     runHistory: [],
     leaderboard: [],
     lifetimeStats: { ...EMPTY_LIFETIME_STATS, killsByType: {} },
@@ -36,6 +38,8 @@ describe("usePersistenceStore", () => {
       const state = usePersistenceStore.getState();
       expect(state.loaded).toBe(false);
       expect(state.available).toBe(false);
+      expect(state.loadError).toBeNull();
+      expect(state.saveError).toBeNull();
       expect(state.runHistory).toEqual([]);
       expect(state.leaderboard).toEqual([]);
       expect(state.lifetimeStats.totalRuns).toBe(0);
@@ -56,6 +60,38 @@ describe("usePersistenceStore", () => {
       expect(state.runHistory).toEqual([]);
       expect(state.leaderboard).toEqual([]);
       expect(state.lifetimeStats.totalRuns).toBe(0);
+      expect(state.loadError).toBeNull();
+    });
+
+    it("sets loadError when IndexedDB read fails", async () => {
+      const originalOpen = indexedDB.open.bind(indexedDB);
+      _resetDBConnection(); // Clear cached connection so openDB() must re-open
+      Object.defineProperty(indexedDB, "open", {
+        value: () => { throw new Error("DB blocked"); },
+        writable: true,
+      });
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await usePersistenceStore.getState().loadFromDB();
+
+      const state = usePersistenceStore.getState();
+      expect(state.loaded).toBe(true);
+      expect(state.available).toBe(false);
+      expect(state.loadError).toBeTruthy();
+      expect(state.loadError).toContain("Failed to load");
+
+      // Restore before afterEach/next beforeEach runs clearAllRuns
+      Object.defineProperty(indexedDB, "open", { value: originalOpen, writable: true });
+      errorSpy.mockRestore();
+    });
+
+    it("clears loadError on successful load", async () => {
+      usePersistenceStore.setState({ loadError: "prior error" });
+
+      await usePersistenceStore.getState().loadFromDB();
+
+      const state = usePersistenceStore.getState();
+      expect(state.loadError).toBeNull();
     });
   });
 
@@ -136,6 +172,58 @@ describe("usePersistenceStore", () => {
       expect(stats.totalTimePlayed).toBe(700);
       expect(stats.longestRunTime).toBe(500);
       expect(stats.highestDay).toBe(3);
+    });
+
+    it("sets saveError when saveRun fails", async () => {
+      await usePersistenceStore.getState().loadFromDB();
+
+      // Break the DB after successful load — clear cache so openDB must re-open
+      const originalOpen = indexedDB.open.bind(indexedDB);
+      _resetDBConnection();
+      Object.defineProperty(indexedDB, "open", {
+        value: () => { throw new Error("DB blocked"); },
+        writable: true,
+      });
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      await usePersistenceStore.getState().recordRun({
+        seed: "test",
+        elapsedTotal: 100,
+        dayNumber: 1,
+        waveNumber: 1,
+        totalKills: 5,
+        killsByType: {},
+        barricadesBuilt: 0,
+        distanceTraveled: 1000,
+        objectsUsed: 0,
+      });
+
+      const state = usePersistenceStore.getState();
+      expect(state.saveError).toBeTruthy();
+      expect(state.saveError).toContain("may not have been saved");
+
+      // Restore before afterEach/next beforeEach runs clearAllRuns
+      Object.defineProperty(indexedDB, "open", { value: originalOpen, writable: true });
+      errorSpy.mockRestore();
+    });
+
+    it("clears saveError on successful save", async () => {
+      usePersistenceStore.setState({ saveError: "prior save error" });
+      await usePersistenceStore.getState().loadFromDB();
+
+      await usePersistenceStore.getState().recordRun({
+        seed: "test",
+        elapsedTotal: 100,
+        dayNumber: 1,
+        waveNumber: 1,
+        totalKills: 5,
+        killsByType: {},
+        barricadesBuilt: 0,
+        distanceTraveled: 1000,
+        objectsUsed: 0,
+      });
+
+      expect(usePersistenceStore.getState().saveError).toBeNull();
     });
 
     it("orders leaderboard by score descending", async () => {

--- a/src/stores/usePersistenceStore.ts
+++ b/src/stores/usePersistenceStore.ts
@@ -30,6 +30,10 @@ export interface PersistenceStoreState {
   loaded: boolean;
   /** Whether IndexedDB is available in this environment. */
   available: boolean;
+  /** Error message from the most recent load attempt, or null. */
+  loadError: string | null;
+  /** Error message from the most recent save attempt, or null. */
+  saveError: string | null;
   /** Recent completed runs (newest first, max 20). */
   runHistory: CompletedRun[];
   /** Top runs by score (highest first, max 10). */
@@ -62,6 +66,8 @@ export interface PersistenceStoreActions {
     distanceTraveled: number;
     objectsUsed: number;
   }) => Promise<void>;
+  /** Dismiss the save error banner. */
+  clearSaveError: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +77,8 @@ export interface PersistenceStoreActions {
 const initialState: PersistenceStoreState = {
   loaded: false,
   available: false,
+  loadError: null,
+  saveError: null,
   runHistory: [],
   leaderboard: [],
   lifetimeStats: { ...EMPTY_LIFETIME_STATS },
@@ -101,13 +109,18 @@ export const usePersistenceStore = create<
       set({
         loaded: true,
         available: true,
+        loadError: null,
         runHistory,
         leaderboard,
         lifetimeStats,
       });
     } catch (err) {
-      console.warn("[PersistenceStore] Failed to load from IndexedDB:", err);
-      set({ loaded: true, available: false });
+      console.error("[PersistenceStore] Failed to load from IndexedDB:", err);
+      set({
+        loaded: true,
+        available: false,
+        loadError: "Failed to load saved data. Your run history may be unavailable.",
+      });
     }
   },
 
@@ -127,8 +140,14 @@ export const usePersistenceStore = create<
       score: computeRunScore(stats),
     };
 
-    // Save to IndexedDB (async, non-blocking)
-    await saveRun(run);
+    // Save to IndexedDB
+    try {
+      await saveRun(run);
+      set({ saveError: null });
+    } catch (err) {
+      console.error("[PersistenceStore] Failed to save run:", err);
+      set({ saveError: "This run may not have been saved." });
+    }
 
     // Refresh cached data from DB
     try {
@@ -149,4 +168,6 @@ export const usePersistenceStore = create<
       }));
     }
   },
+
+  clearSaveError: () => set({ saveError: null }),
 }));


### PR DESCRIPTION
## Summary
- Persistence functions (`saveRun`, `loadRunHistory`, `getLeaderboard`, `getLifetimeStats`, `clearAllRuns`) now re-throw errors after `console.error` instead of returning empty defaults with `console.warn`
- `usePersistenceStore` gains `loadError` and `saveError` fields to distinguish "no data" from "failed to load/save"
- Death screen shows amber warning banner when run save fails
- Landing page shows amber warning banner when IndexedDB load fails
- 14 new tests across persistence, store, and UI components verify error state handling

Resolves #140

## Review
Reviewed by the Forge Temperer. All 6 acceptance criteria verified. 2142/2142 tests pass. Types clean. Lint clean (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)