### PR TITLE
Add error logging to keybindings persistence

### DIFF
--- a/src/lib/keybindings.test.ts
+++ b/src/lib/keybindings.test.ts
@@ -59,9 +59,15 @@ describe("keybindings", () => {
   });
 
   it("loadKeybindings handles corrupt data gracefully", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     store.set("deadbolt-keybindings", "not-json");
     const loaded = loadKeybindings();
     expect(loaded).toEqual(DEFAULT_KEYBINDINGS);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[Keybindings] Failed to load keybindings, using defaults:",
+      expect.any(SyntaxError),
+    );
+    warnSpy.mockRestore();
   });
 
   it("findConflict detects duplicate key bindings", () => {
@@ -89,6 +95,29 @@ describe("keybindings", () => {
       expect(ACTION_META[key].label).toBeTruthy();
       expect(ACTION_META[key].category).toBeTruthy();
     }
+  });
+
+  it("saveKeybindings logs unexpected setItem errors", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockLocalStorage.setItem.mockImplementationOnce(() => {
+      throw new TypeError("unexpected");
+    });
+    saveKeybindings(DEFAULT_KEYBINDINGS);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[Keybindings] Unexpected error saving keybindings:",
+      expect.any(TypeError),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("saveKeybindings silences QuotaExceededError", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockLocalStorage.setItem.mockImplementationOnce(() => {
+      throw new DOMException("Storage full", "QuotaExceededError");
+    });
+    expect(() => saveKeybindings(DEFAULT_KEYBINDINGS)).not.toThrow();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 
   it("default keybindings have no conflicts", () => {

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -109,7 +109,8 @@ export function loadKeybindings(): KeyBindingMap {
     }
 
     return result;
-  } catch {
+  } catch (err) {
+    console.warn("[Keybindings] Failed to load keybindings, using defaults:", err);
     return { ...DEFAULT_KEYBINDINGS };
   }
 }
@@ -119,8 +120,12 @@ export function saveKeybindings(bindings: KeyBindingMap): void {
   if (typeof localStorage === "undefined") return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(bindings));
-  } catch {
-    // Ignore storage errors (quota, restricted env)
+  } catch (err) {
+    // QuotaExceededError and SecurityError are expected in restricted environments.
+    const name = err instanceof DOMException ? err.name : "";
+    if (name !== "QuotaExceededError" && name !== "SecurityError") {
+      console.error("[Keybindings] Unexpected error saving keybindings:", err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `loadKeybindings` now logs `console.warn` on failure instead of silently returning defaults
- `saveKeybindings` now differentiates expected errors (QuotaExceededError, SecurityError) from unexpected ones, logging `console.error` for the latter
- Pattern matches `settings.ts` exactly for codebase consistency
- 2 new tests verify save error logging and QuotaExceededError silencing; existing corrupt-data test updated to assert warning

Resolves #141

## Review
Reviewed by the Forge Temperer. All 5 acceptance criteria verified. 2144/2144 tests pass. Types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)