### PR TITLE
Log warning when WFC solver falls back to deterministic grid

### DIFF
--- a/src/game/procgen/wfc.test.ts
+++ b/src/game/procgen/wfc.test.ts
@@ -8,7 +8,7 @@
  * fallback generator, full pipeline, and edge cases.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import seedrandom from 'seedrandom';
 import type { PRNG } from 'seedrandom';
 import { TileType } from '@/types/procgen';
@@ -898,6 +898,16 @@ describe('generateCityLayout', () => {
 // ---------------------------------------------------------------------------
 
 describe('retry and fallback resilience', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it('generateCityLayout never throws for many seeds across grid sizes', () => {
     const seeds = [
       'retry-a', 'retry-b', 'retry-c', 'retry-d', 'retry-e',
@@ -932,6 +942,13 @@ describe('retry and fallback resilience', () => {
     // Across all 40 runs, the pipeline should produce meaningful output
     expect(totalBuildings).toBeGreaterThan(0);
     expect(totalRoadTiles).toBeGreaterThan(0);
+
+    // Small grids trigger the fallback path — verify the warning fires
+    expect(warnSpy).toHaveBeenCalled();
+    const wfcWarnings = warnSpy.mock.calls.filter((args: unknown[]) =>
+      String(args[0]).includes("[WFC]"),
+    );
+    expect(wfcWarnings.length).toBeGreaterThan(0);
   });
 
   it('fallback grid produces valid pipeline output with buildings', () => {

--- a/src/game/procgen/wfc.ts
+++ b/src/game/procgen/wfc.ts
@@ -723,6 +723,9 @@ export function generateCityLayout(
   }
 
   // Fallback: deterministic simple grid
+  console.warn(
+    `[WFC] All ${WFC.MAX_RETRIES} attempts failed for seed "${seed}" — using deterministic fallback grid`,
+  );
   const fallbackRng = seedrandom(`${seed}-fallback`);
   const macroGrid = generateFallbackGrid(width, height, fallbackRng);
   return buildResult(macroGrid, width, height, seed);


### PR DESCRIPTION
## Summary
- WFC fallback path now logs `console.warn` with seed value and retry count when all solver attempts fail
- Resilience tests use scoped `console.warn` spy to suppress expected warnings
- Added assertion confirming the fallback warning fires for small grids (smoke test)

Resolves #142

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified. 2144/2144 tests pass. Types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)