### PR TITLE
Remove unused imports, dead variables, and eslint directive

### DIFF
--- a/src/components/death-screen.tsx
+++ b/src/components/death-screen.tsx
@@ -6,7 +6,6 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Button } from "@/components/ui/button";
 import { useUIStore } from "@/stores/useUIStore";
 import { useGameStore } from "@/stores/useGameStore";
-import { usePlayerStore } from "@/stores/usePlayerStore";
 import { usePersistenceStore } from "@/stores/usePersistenceStore";
 import { resetSessionStores } from "@/stores/resetSessionStores";
 import { computeRunScore } from "@/types/persistence";

--- a/src/game/ecs/zombie-pool.ts
+++ b/src/game/ecs/zombie-pool.ts
@@ -9,7 +9,7 @@
  * NO React imports — this is pure TypeScript.
  */
 
-import type { ZombieVariant, ZombieType } from "./components";
+import type { ZombieVariant } from "./components";
 import type { Entity } from "./entity";
 import type { ZombieEntity } from "./archetypes";
 import type { BodyRegistry } from "@/game/systems/body-registry";

--- a/src/game/systems/fire-system.ts
+++ b/src/game/systems/fire-system.ts
@@ -183,8 +183,6 @@ export function createFireSystem(ctx: SceneContext): SystemFn {
           FIRE.SPREAD_RADIUS,
         );
 
-        const sourceObjectType = getObjectType(entity);
-
         for (const result of flammables) {
           const target = result.entity;
 

--- a/src/game/systems/zombie-ai-system.ts
+++ b/src/game/systems/zombie-ai-system.ts
@@ -140,19 +140,9 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
   const pathCache = new Map<Entity, CachedPath>();
 
   // --- A* frame budget tracking ---
-  let aStarCallsThisTick = 0;
   let aStarBudgetExhausted = false;
 
-  // --- Topology change listener ---
-  let topologyDirty = false;
-  let lastTopologyChangeTileX = 0;
-  let lastTopologyChangeTileY = 0;
-
   ctx.eventBus.on("topology-changed", (e) => {
-    topologyDirty = true;
-    lastTopologyChangeTileX = e.tileX;
-    lastTopologyChangeTileY = e.tileY;
-
     // Invalidate flow field
     if (flowField) flowField.invalidate();
 
@@ -189,7 +179,6 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
 
     // --- Reset per-tick tracking ---
     toRemove.length = 0;
-    aStarCallsThisTick = 0;
     aStarBudgetExhausted = false;
     const tickStart = now();
 
@@ -218,9 +207,6 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
       }
     }
 
-    // Reset topology dirty flag after flow field recompute
-    topologyDirty = false;
-
     // --- Zombie loop ---
     for (const entity of zombieEntities) {
       const { aiState: ai, zombieType: stats, health } = entity;
@@ -246,7 +232,6 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
         case "idle":
           ai.state = "pathing";
           handlePathingInit(entity, ai, pathfindingGrid, safehouseCenter, noiseMap, tickStart);
-          // eslint-disable-next-line no-fallthrough
         case "pathing":
           runPathingState(entity, dt, pathfindingGrid, safehouseCenter, player, noiseMap, tickStart);
           break;
@@ -536,7 +521,6 @@ export function createZombieAISystem(ctx: SceneContext): SystemFn {
 
     // --- A* search ---
     const result = pathfindingGrid.findSmoothedPath(start, target);
-    aStarCallsThisTick++;
 
     if (result.found) {
       ai.path = result.path;


### PR DESCRIPTION
## Summary
- Remove unused `usePlayerStore` import from `death-screen.tsx`
- Remove unused `ZombieType` import from `zombie-pool.ts`
- Remove 4 dead variables from `zombie-ai-system.ts` (remnants of incomplete A* budget monitoring)
- Remove unnecessary `eslint-disable-next-line no-fallthrough` directive
- Remove unused `sourceObjectType` variable from `fire-system.ts`
- ESLint warnings reduced from 39 to 31 (net -19 lines)

Resolves #145

## Review
Reviewed by the Forge Temperer. All acceptance criteria verified. Tests pass (2166/2166), TypeScript clean, ESLint reduced by 8 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)