### PR TITLE
Log errors from SystemRunner callback catch blocks

### DIFF
--- a/src/game/systems/system-runner.test.ts
+++ b/src/game/systems/system-runner.test.ts
@@ -442,6 +442,51 @@ describe("SystemRunner", () => {
       consoleSpy.mockRestore();
       warnSpy.mockRestore();
     });
+
+    it("logs when onError callback throws", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const callbackError = new Error("callback boom");
+      const failing: SystemFn = () => { throw new Error("sys"); };
+      const runner = new SystemRunner([failing], {
+        names: ["TestSys"],
+        onError: () => { throw callbackError; },
+      });
+
+      runner.run(DT);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[SystemRunner] onError callback threw for "TestSys":',
+        callbackError,
+      );
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("logs when onDisabled callback throws", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const callbackError = new Error("disabled boom");
+      const failing: SystemFn = () => { throw new Error("sys"); };
+      const runner = new SystemRunner([failing], {
+        names: ["TestSys"],
+        errorBudget: 1,
+        onDisabled: () => { throw callbackError; },
+      });
+
+      runner.run(DT);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[SystemRunner] onDisabled callback threw for "TestSys":',
+        callbackError,
+      );
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
   });
 
   describe("disabledCount", () => {

--- a/src/game/systems/system-runner.ts
+++ b/src/game/systems/system-runner.ts
@@ -106,14 +106,22 @@ export class SystemRunner {
           `[${name}] System error ${count}/${this.errorBudget}:`,
           err,
         );
-        try { this._onError?.(i, name, err, count); } catch { /* swallow — callback must not break isolation */ }
+        try {
+          this._onError?.(i, name, err, count);
+        } catch (cbErr) {
+          console.error(`[SystemRunner] onError callback threw for "${name}":`, cbErr);
+        }
 
         if (count >= this.errorBudget) {
           this.disabledFlags[i] = true;
           console.warn(
             `[${name}] Disabled after ${count} errors`,
           );
-          try { this._onDisabled?.(i, name); } catch { /* swallow — callback must not break isolation */ }
+          try {
+            this._onDisabled?.(i, name);
+          } catch (cbErr) {
+            console.error(`[SystemRunner] onDisabled callback threw for "${name}":`, cbErr);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Replaced 2 empty catch blocks in `SystemRunner.run()` with `console.error` logging
- Preserves error isolation (callbacks still can't break the system loop) while making failures visible in developer tools
- Added 2 tests verifying the error messages are logged with system name and caught error

Resolves #168

## Review
Reviewed by the Forge Temperer. All 3 acceptance criteria verified. All 2183 tests pass. Minimal, surgical change consistent with existing logging patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)