### PR TITLE
Drop-in atlas pipeline — external art replacement support

### DIFF
--- a/public/assets/sprites/SPRITES.md
+++ b/public/assets/sprites/SPRITES.md
@@ -1,0 +1,98 @@
+# Sprite Atlas Guide
+
+This directory accepts optional PNG+JSON texture atlas files that replace the programmatic (canvas-generated) sprites. Placing atlas files here is all that's needed — the sprite registry detects them automatically at boot and prioritises atlas frames over generated sprites.
+
+## Atlas Files
+
+| File | Contents | Sprite Keys |
+|------|----------|-------------|
+| `entities.png` + `entities.json` | Player, zombies, bullet | `player`, `zombie`, `zombie_runner`, `zombie_brute`, `zombie_horde`, `bullet` |
+| `objects.png` + `objects.json` | Interactive world objects | `bookshelf`, `wooden_chair`, `table`, `sofa`, `bed`, `gas_can`, `car_battery`, `wire_spool`, `wooden_plank`, `metal_sheet`, `fridge`, `metal_shelving`, `cardboard_box`, `trash_can`, `tire` |
+| `ui.png` + `ui.json` | 16×16 inventory icons | `ui_bookshelf`, `ui_wooden_chair`, `ui_table`, `ui_sofa`, `ui_bed`, `ui_gas_can`, `ui_car_battery`, `ui_wire_spool`, `ui_wooden_plank`, `ui_metal_sheet`, `ui_fridge`, `ui_metal_shelving`, `ui_cardboard_box`, `ui_trash_can`, `ui_tire` |
+
+All three files are **optional**. Any combination works — you can provide only `entities.png`+`entities.json` and objects will continue using programmatic sprites.
+
+## Format
+
+**JSON Hash** (Phaser standard) — compatible with TexturePacker, Aseprite, and free-tex-packer.
+
+```json
+{
+  "frames": {
+    "zombie": {
+      "frame": { "x": 0, "y": 0, "w": 20, "h": 20 },
+      "sourceSize": { "w": 20, "h": 20 },
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 20, "h": 20 }
+    },
+    "zombie_runner": {
+      "frame": { "x": 20, "y": 0, "w": 18, "h": 18 },
+      "sourceSize": { "w": 18, "h": 18 },
+      "spriteSourceSize": { "x": 0, "y": 0, "w": 18, "h": 18 }
+    }
+  },
+  "meta": {
+    "image": "entities.png",
+    "format": "RGBA8888",
+    "size": { "w": 512, "h": 512 }
+  }
+}
+```
+
+## Frame Naming Convention
+
+Frame names in the JSON **must match the sprite key exactly**:
+
+| Entity | Frame Name | Size | Notes |
+|--------|-----------|------|-------|
+| Player (south idle) | `player` | 24×24 | Default facing direction |
+| Zombie (shambler) | `zombie` | 20×20 | |
+| Zombie (runner) | `zombie_runner` | 18×18 | |
+| Zombie (brute) | `zombie_brute` | 28×28 | |
+| Zombie (horde) | `zombie_horde` | 12×12 | |
+| Bullet | `bullet` | 6×6 | |
+
+### Object Frame Names
+
+| Object | Frame Name | Size |
+|--------|-----------|------|
+| Bookshelf | `bookshelf` | 32×32 |
+| Wooden Chair | `wooden_chair` | 16×16 |
+| Table | `table` | 16×16 |
+| Sofa | `sofa` | 32×32 |
+| Bed | `bed` | 32×32 |
+| Gas Can | `gas_can` | 16×16 |
+| Car Battery | `car_battery` | 16×16 |
+| Wire Spool | `wire_spool` | 16×16 |
+| Wooden Plank | `wooden_plank` | 16×16 |
+| Metal Sheet | `metal_sheet` | 16×16 |
+| Fridge | `fridge` | 32×32 |
+| Metal Shelving | `metal_shelving` | 32×32 |
+| Cardboard Box | `cardboard_box` | 16×16 |
+| Trash Can | `trash_can` | 16×16 |
+| Tire | `tire` | 16×16 |
+
+## Size Constraints
+
+- **Immovable objects** (bookshelf, sofa, bed, fridge, metal_shelving): **32×32** pixels
+- **Movable objects**: **16×16** pixels
+- **Player**: **24×24** pixels per direction frame
+- **Zombies**: Match visual sizes above (20, 18, 28, or 12 px square)
+- **UI icons**: Always **16×16** pixels
+
+## Colour & Tinting
+
+Sprites are tinted at runtime via `setTint()`:
+- **Entity sprites** (player, zombies, bullet) should be drawn in **white/gray** — the palette tints them to the correct colour
+- **Object sprites** can be drawn in their **final colours** if desired, since objects use category-based tints (furniture = brown, loot = gold, containers = gray, debris = dark gray)
+
+If drawing white sprites for tinting: `white × tint colour = tint colour`. If drawing coloured sprites: set the object's `renderColor` to `0xffffff` in `object-defs.ts` to disable tinting.
+
+## Partial Atlas Support
+
+You can include only some frames in an atlas. Missing frames automatically fall back to programmatic generation. For example, an `entities.json` with only `"zombie"` and `"zombie_brute"` will use atlas art for those two and programmatic sprites for everything else.
+
+## Tools
+
+- [TexturePacker](https://www.codeandweb.com/texturepacker) — Export as "JSON Hash"
+- [Aseprite](https://www.aseprite.org/) — File → Export Sprite Sheet → JSON Hash
+- [free-tex-packer](https://free-tex-packer.com/) — Free online alternative

--- a/src/game/rendering/index.ts
+++ b/src/game/rendering/index.ts
@@ -7,6 +7,7 @@ export {
   getSpriteRegistry,
   initializeSpriteRegistry,
   resetSpriteRegistry,
+  ATLAS_KEYS,
 } from "./sprite-registry";
 export type { SpriteEntry } from "./sprite-registry";
 

--- a/src/game/rendering/sprite-registry.test.ts
+++ b/src/game/rendering/sprite-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { SpriteRegistry, resetSpriteRegistry } from "./sprite-registry";
+import { SpriteRegistry, resetSpriteRegistry, ATLAS_KEYS } from "./sprite-registry";
 
 // ---------------------------------------------------------------------------
 // Mock Phaser scene with texture manager
@@ -17,6 +17,12 @@ function createMockScene() {
   const existingKeys = new Set<string>();
   const mockTextureAdd = vi.fn();
 
+  /**
+   * Atlas mock: maps atlasKey → set of frame names.
+   * Populate via `atlasFrames.set("atlas-entities", new Set(["zombie"]))`.
+   */
+  const atlasFrames = new Map<string, Set<string>>();
+
   const scene = {
     textures: {
       exists: vi.fn().mockImplementation((key: string) => existingKeys.has(key)),
@@ -26,11 +32,17 @@ function createMockScene() {
         canvases.push(canvas);
         return canvas;
       }),
-      get: vi.fn().mockReturnValue({ add: mockTextureAdd }),
+      get: vi.fn().mockImplementation((key: string) => {
+        const frames = atlasFrames.get(key);
+        return {
+          add: mockTextureAdd,
+          has: (frameName: string) => frames?.has(frameName) ?? false,
+        };
+      }),
     },
   } as unknown as Phaser.Scene;
 
-  return { scene, canvases, existingKeys, mockTextureAdd };
+  return { scene, canvases, existingKeys, mockTextureAdd, atlasFrames };
 }
 
 describe("SpriteRegistry", () => {
@@ -299,5 +311,100 @@ describe("SpriteRegistry", () => {
     expect(entry.textureKey).toBe("spr_ui_bookshelf");
     expect(entry.width).toBe(16);
     expect(entry.height).toBe(16);
+  });
+
+  // -------------------------------------------------------------------------
+  // Atlas pipeline (issue #181)
+  // -------------------------------------------------------------------------
+
+  it("prioritises atlas frame over programmatic generation", () => {
+    const { scene, canvases, existingKeys, atlasFrames } = createMockScene();
+
+    // Simulate a loaded atlas with a "zombie" frame
+    existingKeys.add(ATLAS_KEYS.ENTITIES);
+    atlasFrames.set(ATLAS_KEYS.ENTITIES, new Set(["zombie"]));
+
+    const registry = new SpriteRegistry();
+    registry.initialize(scene);
+
+    // Entry should use the atlas texture key + frame name
+    const entry = registry.get("zombie");
+    expect(entry.textureKey).toBe(ATLAS_KEYS.ENTITIES);
+    expect(entry.defaultFrame).toBe("zombie");
+
+    // No programmatic canvas should have been created for zombie
+    const zombieCanvas = canvases.find((c) => c.key === "spr_zombie");
+    expect(zombieCanvas).toBeUndefined();
+  });
+
+  it("falls back to programmatic generation when atlas has no matching frame", () => {
+    const { scene, canvases, existingKeys, atlasFrames } = createMockScene();
+
+    // Atlas loaded but contains no zombie frame
+    existingKeys.add(ATLAS_KEYS.ENTITIES);
+    atlasFrames.set(ATLAS_KEYS.ENTITIES, new Set(["bullet"]));
+
+    const registry = new SpriteRegistry();
+    registry.initialize(scene);
+
+    // Zombie should still be programmatically generated
+    const entry = registry.get("zombie");
+    expect(entry.textureKey).toBe("spr_zombie");
+
+    const zombieCanvas = canvases.find((c) => c.key === "spr_zombie");
+    expect(zombieCanvas).toBeDefined();
+  });
+
+  it("supports partial atlas coverage (some frames from atlas, rest programmatic)", () => {
+    const { scene, canvases, existingKeys, atlasFrames } = createMockScene();
+
+    // Atlas has zombie but not zombie_runner
+    existingKeys.add(ATLAS_KEYS.ENTITIES);
+    atlasFrames.set(ATLAS_KEYS.ENTITIES, new Set(["zombie"]));
+
+    const registry = new SpriteRegistry();
+    registry.initialize(scene);
+
+    // zombie → atlas
+    expect(registry.get("zombie").textureKey).toBe(ATLAS_KEYS.ENTITIES);
+    // zombie_runner → programmatic
+    expect(registry.get("zombie_runner").textureKey).toBe("spr_zombie_runner");
+    // player → programmatic (not in atlas)
+    expect(registry.get("player").textureKey).toBe("spr_player");
+  });
+
+  it("falls back gracefully when no atlas files are loaded (current state)", () => {
+    const { scene, canvases } = createMockScene();
+    // No atlas keys in existingKeys — default state
+    const registry = new SpriteRegistry();
+    registry.initialize(scene);
+
+    // All entries should use spr_ prefix (programmatic)
+    expect(registry.get("player").textureKey).toBe("spr_player");
+    expect(registry.get("zombie").textureKey).toBe("spr_zombie");
+    expect(registry.get("bookshelf").textureKey).toBe("spr_bookshelf");
+
+    // Programmatic canvases should have been created
+    expect(canvases.length).toBeGreaterThan(10);
+  });
+
+  it("prioritises atlas frames for UI icons", () => {
+    const { scene, existingKeys, atlasFrames } = createMockScene();
+
+    existingKeys.add(ATLAS_KEYS.UI);
+    atlasFrames.set(ATLAS_KEYS.UI, new Set(["ui_bookshelf"]));
+
+    const registry = new SpriteRegistry();
+    registry.initialize(scene);
+
+    const entry = registry.get("ui_bookshelf");
+    expect(entry.textureKey).toBe(ATLAS_KEYS.UI);
+    expect(entry.defaultFrame).toBe("ui_bookshelf");
+  });
+
+  it("exports ATLAS_KEYS constants", () => {
+    expect(ATLAS_KEYS.ENTITIES).toBe("atlas-entities");
+    expect(ATLAS_KEYS.OBJECTS).toBe("atlas-objects");
+    expect(ATLAS_KEYS.UI).toBe("atlas-ui");
   });
 });

--- a/src/game/rendering/sprite-registry.ts
+++ b/src/game/rendering/sprite-registry.ts
@@ -71,6 +71,44 @@ const ZOMBIE_VISUAL_SIZES: Readonly<Record<string, number>> = {
 const TEX_PREFIX = "spr_";
 
 // ---------------------------------------------------------------------------
+// Atlas support
+// ---------------------------------------------------------------------------
+
+/**
+ * Atlas texture keys that the preload phase attempts to load.
+ * If an atlas is loaded, its frame names are checked against sprite keys
+ * before falling back to programmatic generation.
+ */
+export const ATLAS_KEYS = {
+  ENTITIES: "atlas-entities",
+  OBJECTS: "atlas-objects",
+  UI: "atlas-ui",
+} as const;
+
+/** All atlas keys as an iterable array. */
+const ALL_ATLAS_KEYS = Object.values(ATLAS_KEYS);
+
+/**
+ * Check loaded atlases for a frame matching the given sprite key.
+ *
+ * Returns the atlas texture key if a match is found, or `null` if no
+ * atlas contains this frame. Frame names in the atlas JSON must match
+ * the sprite key exactly (e.g. `"player"`, `"zombie"`, `"bookshelf"`).
+ */
+function findAtlasFrame(
+  scene: Phaser.Scene,
+  spriteKey: string,
+): string | null {
+  for (const atlasKey of ALL_ATLAS_KEYS) {
+    if (!scene.textures.exists(atlasKey)) continue;
+    const tex = scene.textures.get(atlasKey);
+    // Phaser Texture.has() checks if a frame name exists
+    if (tex.has(spriteKey)) return atlasKey;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Known entity sprite keys (hard-coded manifest)
 // ---------------------------------------------------------------------------
 
@@ -130,7 +168,19 @@ export class SpriteRegistry {
     for (const { spriteKey, width, height } of manifest) {
       const textureKey = `${TEX_PREFIX}${spriteKey}`;
 
-      // Hot-swap: if an atlas already provides this texture, skip generation
+      // 1. Atlas priority: check if any loaded atlas has a frame for this key
+      const atlasKey = findAtlasFrame(scene, spriteKey);
+      if (atlasKey) {
+        this.entries.set(spriteKey, {
+          textureKey: atlasKey,
+          width,
+          height,
+          defaultFrame: spriteKey,
+        });
+        continue;
+      }
+
+      // 2. Hot-swap: if a standalone texture already exists, skip generation
       if (!scene.textures.exists(textureKey)) {
         const generator = getEntitySpriteGenerator(spriteKey) ?? getObjectSpriteGenerator(spriteKey);
         if (generator) {
@@ -158,6 +208,14 @@ export class SpriteRegistry {
     for (const def of getAllObjectDefs()) {
       const uiKey = `ui_${def.type}`;
       const uiTextureKey = `${TEX_PREFIX}${uiKey}`;
+
+      // Atlas priority for UI icons
+      const uiAtlasKey = findAtlasFrame(scene, uiKey);
+      if (uiAtlasKey) {
+        this.entries.set(uiKey, { textureKey: uiAtlasKey, width: 16, height: 16, defaultFrame: uiKey });
+        continue;
+      }
+
       if (!scene.textures.exists(uiTextureKey)) {
         const uiGen = getUiSpriteGenerator(def.type);
         if (uiGen) {

--- a/src/game/scenes/boot-scene.test.ts
+++ b/src/game/scenes/boot-scene.test.ts
@@ -3,7 +3,7 @@ import BootScene from "@/game/scenes/boot-scene";
 import { PLAYER_TEXTURE_KEY, PLAYER_SIZE } from "@/game/scenes/boot-scene";
 import { TILE_SIZE } from "@/game/tiles/tile-types";
 import { TILESET_KEY } from "@/game/tiles/tileset-generator";
-import { resetSpriteRegistry } from "@/game/rendering/sprite-registry";
+import { resetSpriteRegistry, ATLAS_KEYS } from "@/game/rendering/sprite-registry";
 
 // ---------------------------------------------------------------------------
 // Mock factories
@@ -30,8 +30,14 @@ function createMockScene() {
   scene.textures = {
     createCanvas: vi.fn().mockImplementation(() => createMockCanvasTexture()),
     exists: vi.fn().mockReturnValue(false),
-    get: vi.fn().mockReturnValue({ add: vi.fn() }),
+    get: vi.fn().mockReturnValue({ add: vi.fn(), has: vi.fn().mockReturnValue(false) }),
   } as unknown as Phaser.Textures.TextureManager;
+
+  scene.load = {
+    atlas: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+  } as unknown as Phaser.Loader.LoaderPlugin;
 
   scene.game = {
     events: {
@@ -162,5 +168,51 @@ describe("BootScene", () => {
 
     expect(scene.scene.start).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Atlas preloading (issue #181)
+  // -------------------------------------------------------------------------
+
+  describe("atlas preloading", () => {
+    it("has a preload method", () => {
+      expect(typeof scene.preload).toBe("function");
+    });
+
+    it("queues three atlas files in preload", () => {
+      scene.preload();
+
+      const loadAtlas = scene.load.atlas as ReturnType<typeof vi.fn>;
+      expect(loadAtlas).toHaveBeenCalledTimes(3);
+      expect(loadAtlas).toHaveBeenCalledWith(
+        ATLAS_KEYS.ENTITIES,
+        "/assets/sprites/entities.png",
+        "/assets/sprites/entities.json",
+      );
+      expect(loadAtlas).toHaveBeenCalledWith(
+        ATLAS_KEYS.OBJECTS,
+        "/assets/sprites/objects.png",
+        "/assets/sprites/objects.json",
+      );
+      expect(loadAtlas).toHaveBeenCalledWith(
+        ATLAS_KEYS.UI,
+        "/assets/sprites/ui.png",
+        "/assets/sprites/ui.json",
+      );
+    });
+
+    it("registers a loaderror handler for graceful fallback", () => {
+      scene.preload();
+
+      const loadOn = scene.load.on as ReturnType<typeof vi.fn>;
+      expect(loadOn).toHaveBeenCalledWith("loaderror", expect.any(Function));
+    });
+
+    it("registers a complete handler for logging", () => {
+      scene.preload();
+
+      const loadOnce = scene.load.once as ReturnType<typeof vi.fn>;
+      expect(loadOnce).toHaveBeenCalledWith("complete", expect.any(Function));
+    });
   });
 });

--- a/src/game/scenes/boot-scene.ts
+++ b/src/game/scenes/boot-scene.ts
@@ -3,7 +3,7 @@ import { generateTileset } from "@/game/tiles/tileset-generator";
 import { TILE_SIZE } from "@/game/tiles/tile-types";
 import { ALL_SOUND_KEYS } from "@/game/systems/audio-constants";
 import { PARTICLE_TEXTURES } from "@/game/systems/particle-constants";
-import { initializeSpriteRegistry } from "@/game/rendering/sprite-registry";
+import { initializeSpriteRegistry, ATLAS_KEYS } from "@/game/rendering/sprite-registry";
 import { PARTICLE_GENERATORS } from "@/game/rendering/generators/particle-sprites";
 
 /** Texture key for the player sprite. */
@@ -20,6 +20,51 @@ export const PLAYER_SIZE = 24;
 export default class BootScene extends Phaser.Scene {
   constructor() {
     super({ key: "BootScene" });
+  }
+
+  /**
+   * Attempt to load external atlas files from public/assets/sprites/.
+   *
+   * Atlas files are optional — if they don't exist, Phaser's loader fires
+   * error events that we catch and silently ignore. Any successfully loaded
+   * atlas frames take priority over programmatic generation via the sprite
+   * registry's hot-swap check.
+   *
+   * Atlas format: Phaser-standard JSON Hash (TexturePacker / Aseprite / free-tex-packer).
+   */
+  preload(): void {
+    // Suppress individual file load errors (atlas files are optional)
+    const failedKeys = new Set<string>();
+    this.load.on("loaderror", (file: { key?: string }) => {
+      if (file.key) failedKeys.add(file.key);
+    });
+
+    // Queue atlas files — Phaser will skip missing files via the error handler
+    this.load.atlas(
+      ATLAS_KEYS.ENTITIES,
+      "/assets/sprites/entities.png",
+      "/assets/sprites/entities.json",
+    );
+    this.load.atlas(
+      ATLAS_KEYS.OBJECTS,
+      "/assets/sprites/objects.png",
+      "/assets/sprites/objects.json",
+    );
+    this.load.atlas(
+      ATLAS_KEYS.UI,
+      "/assets/sprites/ui.png",
+      "/assets/sprites/ui.json",
+    );
+
+    // After all loads complete/fail, log which atlases loaded
+    this.load.once("complete", () => {
+      for (const key of Object.values(ATLAS_KEYS)) {
+        if (failedKeys.has(key)) continue;
+        if (this.textures.exists(key)) {
+          console.info(`[BootScene] Atlas "${key}" loaded — sprites will use atlas frames.`);
+        }
+      }
+    });
   }
 
   create(): void {


### PR DESCRIPTION
## Summary
- Adds BootScene `preload()` phase that attempts to load 3 optional PNG+JSON atlas files (entities, objects, UI) from `public/assets/sprites/`
- Sprite registry checks loaded atlases first via `findAtlasFrame()` before falling back to programmatic generation — per-frame granularity enables incremental art replacement
- Graceful error handling: missing atlas files silently captured via `loaderror` event, successful loads logged via `console.info`
- SPRITES.md documentation (98 lines) provides art contributors with format requirements, frame naming conventions, size constraints, and tool recommendations
- Existing programmatic sprites remain fully functional as baseline — zero-config fallback

Resolves #181

## Review
Reviewed by the Forge Temperer. All 13 acceptance criteria verified. 2413 tests pass, build clean, TypeScript clean. Atlas priority chain (atlas → standalone texture → programmatic) correctly implemented with per-frame granularity and partial coverage support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)